### PR TITLE
Fix debug step in fetch blogs workflow

### DIFF
--- a/.github/workflows/fetch-blogs.yml
+++ b/.github/workflows/fetch-blogs.yml
@@ -29,21 +29,14 @@ jobs:
 
       - name: Debug event payload
         run: |
+          set -euo pipefail
           echo "Event name: $GITHUB_EVENT_NAME"
           if [ -f "$GITHUB_EVENT_PATH" ]; then
-            python3 - <<'PY'
-              import json
-              import os
-
-              path = os.environ.get("GITHUB_EVENT_PATH")
-              if not path or not os.path.exists(path):
-                  print("Could not load event payload.")
-              else:
-                  with open(path, "r", encoding="utf-8") as handle:
-                      data = json.load(handle)
-                  title = data.get("issue", {}).get("title") or "N/A"
-                  print(f"Issue title: {title}")
-PY
+            title=$(jq -r '.issue.title // empty' "$GITHUB_EVENT_PATH")
+            if [ -z "$title" ]; then
+              title="N/A"
+            fi
+            echo "Issue title: $title"
           else
             echo "Event payload file not found."
           fi


### PR DESCRIPTION
## Summary
- replace the Python heredoc in the debug step with a jq-based helper to avoid here-doc termination errors
- harden the workflow step with `set -euo pipefail` while preserving the issue title logging behaviour

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68e8c94cb8fc8327a8b411059e1b6de0