### PR TITLE
📚 Docs: Routine documentation audit and logging

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -81,3 +81,7 @@
 - Audited codebase documentation and verified all `pnpm run lint`, `pnpm run format:check`, and `npx markdown-link-check` passed successfully. No new broken links, unformatted code, or missing JSDocs were found.
 - Added missing JSDoc block to `Modal` component in `src/components/shared/Modal.jsx`.
 - Fixed JSDoc positioning for `TerminalMode` component in `src/components/shared/TerminalMode.jsx` by moving the `// ⚡ Bolt` comment above the JSDoc block.
+
+## 2026-04-08
+
+- Audited codebase documentation and verified all `pnpm run lint`, `pnpm run format:check`, and `npx markdown-link-check` passed successfully. No new broken links, unformatted code, or missing JSDocs were found.


### PR DESCRIPTION
This commit represents a successful run of the Docs agent daily process. 

I checked all `.md` and `.json` files for broken links (excluding node_modules and dist), ran Prettier formatting checks, and verified the build/lint/test suite. Finding no issues that required fixing, I logged the clean state in the `.jules/docs-progress.md` file as directed. 

The `public/sitemap.xml` file changes were restored as they were automatically generated side-effects of the build step and out of scope for the documentation audit.

---
*PR created automatically by Jules for task [15073138317088711251](https://jules.google.com/task/15073138317088711251) started by @saint2706*