### PR TITLE
🛡️ Sentinel: Fixed React-Markdown attribute override vulnerability in ChatInterface

### DIFF
--- a/src/components/shared/ChatInterface.jsx
+++ b/src/components/shared/ChatInterface.jsx
@@ -105,11 +105,11 @@ const LinkRenderer = React.memo(({ href, children, ...rest }) => {
 
   return (
     <a
+      {...rest}
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       className="text-accent underline font-bold"
-      {...rest}
     >
       {children}
     </a>
@@ -140,13 +140,13 @@ const ImageRenderer = React.memo(({ src, alt, ...rest }) => {
 
   return (
     <img
+      {...rest}
       src={src}
       alt={alt || 'Chat image'}
       className="max-w-full h-auto rounded-lg my-2 border-2 border-[color:var(--color-border)]"
       loading="lazy"
       width={800}
       height={600}
-      {...rest}
     />
   );
 });


### PR DESCRIPTION
Fixed a potential security vulnerability in `src/components/shared/ChatInterface.jsx` where `react-markdown` components (`LinkRenderer` and `ImageRenderer`) were rendering `{...rest}` after defining security-critical attributes like `target="_blank"`, `rel="noopener noreferrer"`, and `src`.

If an attacker were able to inject arbitrary attributes via the markdown parser, they could have overridden these attributes. By shifting `{...rest}` before the security-critical ones, we ensure that they cannot be tampered with.

---
*PR created automatically by Jules for task [8383447171456414700](https://jules.google.com/task/8383447171456414700) started by @saint2706*