### PR TITLE
🛡️ Sentinel: Fixed FTP Command Injection via CRLF

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,8 @@
     - Replaced `ast.literal_eval` with `json.loads` in `src/data/snippets.js`.
     - Python's `ast.literal_eval` parses strings into an Abstract Syntax Tree (AST), which is recursive. A user providing deeply nested input (e.g., `[[[[...]]]]`) could cause a stack overflow in Python's C core, causing the Pyodide WebAssembly runtime to crash the browser tab (client-side Denial of Service).
     - `json.loads` is not vulnerable to recursive AST stack exhaustion and provides safer JSON parsing for the `py-flatten` and `py-transpose` snippets.
+
+### basic-ftp FTP Command Injection via CRLF
+
+- **Vulnerability**: GHSA-chqc-8p9q-pq6q
+- **Fix**: Added `"basic-ftp": ">=5.2.1"` to `pnpm.overrides` in `package.json` to resolve vulnerability in `puppeteer-core`'s transitive dependency.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
       "picomatch@^2": "^2.3.2",
       "picomatch@^4": "^4.0.4",
       "yaml": "^2.8.3",
-      "lodash-es": ">=4.18.0"
+      "lodash-es": ">=4.18.0",
+      "basic-ftp": ">=5.2.1"
     },
     "onlyBuiltDependencies": [
       "esbuild"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   picomatch@^4: ^4.0.4
   yaml: ^2.8.3
   lodash-es: '>=4.18.0'
+  basic-ftp: '>=5.2.1'
 
 importers:
 
@@ -1343,8 +1344,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.2.1:
+    resolution: {integrity: sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==}
     engines: {node: '>=10.0.0'}
 
   bidi-js@1.0.3:
@@ -4640,7 +4641,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.7: {}
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.2.1: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -5308,7 +5309,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.2.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
Resolved a High severity FTP Command Injection via CRLF vulnerability in `basic-ftp` (transitive dependency of `puppeteer-core`). 

Applied `pnpm.overrides` in `package.json` to enforce `basic-ftp: >=5.2.1` based on advisory GHSA-chqc-8p9q-pq6q. Updated lockfile and verified that build, lint, and tests pass successfully. Logged learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1299518215236839710](https://jules.google.com/task/1299518215236839710) started by @saint2706*