### PR TITLE
🎨 Picasso: [UX improvement] Add aria-hidden to decorative icons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -72,3 +72,5 @@ Implements various UX and accessibility enhancements across the application, foc
 - Added missing `aria-hidden="true"` to icon components (`<MapPin>`, `<Sparkles>`, `<Send>`, `<Github>`, `<Linkedin>`) used in `src/components/pages/Contact.jsx`.
 - Added missing `aria-hidden="true"` to icon components (`<ArrowUp>`, `<ArrowDown>`, `<CornerDownLeft>`, `<Search>`) used in `src/components/shared/CommandPalette.jsx`.
   This prevents screen readers from redundantly reading the SVG content when the parent elements or the surrounding context already convey the meaning.
+
+- Added `aria-hidden="true"` to `ArrowUp` icon within `ScrollToTop` button to improve accessibility by hiding decorative icons from screen readers when the parent element already provides an `aria-label`.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/components/shared/ScrollToTop.jsx
+++ b/src/components/shared/ScrollToTop.jsx
@@ -105,7 +105,7 @@ const ScrollToTop = React.memo(() => {
           className="group fixed bottom-6 left-6 z-30 p-3 bg-secondary text-primary rounded-full shadow-lg border border-[color:var(--color-border)] hover:border-accent hover:text-accent hover:bg-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-primary)]"
           aria-label="Scroll to top"
         >
-          <ArrowUp size={20} />
+          <ArrowUp size={20} aria-hidden="true" />
           {/* Tooltip */}
           <span
             className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 bg-black text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50 font-sans"


### PR DESCRIPTION
This PR adds `aria-hidden="true"` to decorative icons within icon-only buttons that already have a descriptive `aria-label`. Specifically, this targets the `<ArrowUp>` icon within the `ScrollToTop` button. This prevents screen readers from redundantly reading the SVG content or generic icon names, thereby streamlining the accessibility experience. Tested with `pnpm run build`, `pnpm run lint`, and `pnpm run test:run`.

---
*PR created automatically by Jules for task [6326937805386620285](https://jules.google.com/task/6326937805386620285) started by @saint2706*