### PR TITLE
⚡ Bolt: Lazy load SettingsModal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,4 +78,4 @@
 - **Solution:** I extracted the `emptyStateVariants` object statically outside the `Playground` component so the reference is stable across renders. I then referred to it using the standard `variants={emptyStateVariants}` pattern with string references for states (`initial="initial"`).
 - **Files Modified:** `src/components/pages/Playground.jsx`
 - **Impact:** Reduces object allocation and unnecessary render work when the Playground component mounts or re-renders.
->> [PERF] Lazy load SettingsModal to reduce initial bundle size
+  > > [PERF] Lazy load SettingsModal to reduce initial bundle size

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,4 @@
 - **Solution:** I extracted the `emptyStateVariants` object statically outside the `Playground` component so the reference is stable across renders. I then referred to it using the standard `variants={emptyStateVariants}` pattern with string references for states (`initial="initial"`).
 - **Files Modified:** `src/components/pages/Playground.jsx`
 - **Impact:** Reduces object allocation and unnecessary render work when the Playground component mounts or re-renders.
+>> [PERF] Lazy load SettingsModal to reduce initial bundle size

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -9,7 +9,6 @@ import { useLocation } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import CustomCursor from '../shared/CustomCursor';
-import SettingsModal from '../shared/SettingsModal';
 import { useTheme } from '../shared/theme-context';
 import {
   canUseDOM,
@@ -39,6 +38,7 @@ const KONAMI_CODE = [
 /** Lazy load overlays so they don't impact initial bundle */
 const CommandPalette = lazy(() => import('../shared/CommandPalette'));
 const TerminalMode = lazy(() => import('../shared/TerminalMode'));
+const SettingsModal = lazy(() => import('../shared/SettingsModal'));
 
 /**
  * Layout component that wraps all page content
@@ -318,15 +318,16 @@ const Layout = ({ children }) => {
             welcomeMessage={terminalWelcome}
           />
         )}
+        {isSettingsOpen && (
+          <SettingsModal
+            isOpen={isSettingsOpen}
+            onClose={() => setIsSettingsOpen(false)}
+            cursorEnabled={effectiveCursorEnabled}
+            cursorToggleDisabled={cursorForcedOff}
+            onToggleCursor={toggleCursor}
+          />
+        )}
       </Suspense>
-
-      <SettingsModal
-        isOpen={isSettingsOpen}
-        onClose={() => setIsSettingsOpen(false)}
-        cursorEnabled={effectiveCursorEnabled}
-        cursorToggleDisabled={cursorForcedOff}
-        onToggleCursor={toggleCursor}
-      />
     </div>
   );
 };


### PR DESCRIPTION
Lazy load the `SettingsModal` component in `Layout.jsx` to reduce the initial JavaScript bundle size, deferring loading until the modal is actually opened.

---
*PR created automatically by Jules for task [6483729011666948630](https://jules.google.com/task/6483729011666948630) started by @saint2706*