### PR TITLE
🔄 CI/CD: Optimize sync-blogs workflow by merging sequential jobs

### DIFF
--- a/.github/workflows/sync-blogs.yml
+++ b/.github/workflows/sync-blogs.yml
@@ -16,9 +16,11 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
 
 jobs:
-  generate:
+  sync:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,29 +30,6 @@ jobs:
 
       - name: Run sync script
         run: node scripts/sync-blogs.js
-
-      - name: Upload synced blogs artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: synced-blogs
-          path: src/data/blogs.json
-          if-no-files-found: error
-
-  commit:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: generate
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Download synced blogs artifact
-        uses: actions/download-artifact@b14d97074e5f6f0894f57f9e0cbaec4e90f0f5e5 # v4.1.8
-        with:
-          name: synced-blogs
-          path: src/data
 
       - name: Commit and Push changes
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0

--- a/.jules/ci-cd.md
+++ b/.jules/ci-cd.md
@@ -32,3 +32,8 @@
 
 - Updated `actions/upload-pages-artifact` to a more recent v4 SHA (`56afc609e74202658d3ffba0e8f6dda462b719fa`) in `deploy.yml`.
 - Ensured external actions are pinned to 40-character commit SHAs.
+
+## Workflow Optimization
+
+- **Update**: Merged `generate` and `commit` jobs into a single `sync` job in `.github/workflows/sync-blogs.yml`.
+- **Why**: Eliminates the sequential `needs: generate` constraint and removes the overhead of uploading and downloading artifacts, bypassing a redundant runner spin-up to reduce pipeline duration.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-10</lastmod>
+    <lastmod>2026-04-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
This PR merges the `generate` and `commit` jobs inside `.github/workflows/sync-blogs.yml` into a single `sync` job. 

Previously, the pipeline would spin up a runner to generate the data, upload it as an artifact, and then spin up a *second* runner to download the artifact and commit it. By consolidating these steps into a single job, we completely eliminate the overhead of transferring the artifact over the network and waiting for an additional runner to provision, significantly speeding up the workflow.

---
*PR created automatically by Jules for task [3049681701577851415](https://jules.google.com/task/3049681701577851415) started by @saint2706*