### PR TITLE
🎨 Picasso: Add aria-label to Snake Game resume button

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -74,3 +74,4 @@ Implements various UX and accessibility enhancements across the application, foc
   This prevents screen readers from redundantly reading the SVG content when the parent elements or the surrounding context already convey the meaning.
 
 - Added `aria-hidden="true"` to `ArrowUp` icon within `ScrollToTop` button to improve accessibility by hiding decorative icons from screen readers when the parent element already provides an `aria-label`.
+- Added explicit `aria-label` to the Snake Game resume button to improve accessibility and screen reader support.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-13</lastmod>
+    <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/components/games/SnakeGame.jsx
+++ b/src/components/games/SnakeGame.jsx
@@ -231,6 +231,7 @@ const GameOverlay = React.memo(
             className={ui.buttonSecondary}
             style={ui.style.raised}
             autoFocus
+            aria-label="Resume game"
           >
             <Play size={18} aria-hidden="true" />
             Resume


### PR DESCRIPTION
🎨 Picasso: [UX improvement] Adds `aria-label="Resume game"` to the Snake Game resume button.

This improves screen reader context when interacting with the pause overlay. Cleaned up all temporary discovery artifacts to ensure a pristine commit.

Verified via local test suite (`pnpm run build && pnpm run test:run`) and Playwright visual screenshot.

---
*PR created automatically by Jules for task [14259159763165928556](https://jules.google.com/task/14259159763165928556) started by @saint2706*