### PR TITLE
Migrate Vite manualChunks config for Vite 8 (Rolldown)

### DIFF
--- a/docs/audits/vite8-chunk-migration-2026-04-16.md
+++ b/docs/audits/vite8-chunk-migration-2026-04-16.md
@@ -1,0 +1,48 @@
+# Vite 8 Chunking Migration Notes — 2026-04-16
+
+## Why this change
+
+Vite 8 uses Rolldown for production builds. Under Rolldown, `output.manualChunks` must be
+provided as a function; the previous object-form mapping fails at build time.
+
+## Chunk strategy decision
+
+- **Decision:** keep manual chunking, but migrate from object syntax to a function-based
+  `manualChunks` implementation under `build.rolldownOptions.output`.
+- **Reason:** preserving explicit vendor group names (`vendor-react`, `vendor-ui`, `vendor-ai`)
+  keeps bundle comparisons stable and readable across releases.
+
+## Before vs. after comparison
+
+### Before upgrade (Vite 7 / Rollup baseline)
+
+From the existing baseline audit snapshot:
+
+- Entry chunk reported as `index-BQAvJkkD.js`.
+- Shared vendor chunks include `vendor-ui-Djb_NyiB.js` and `vendor-react-DprNbJ5V.js`.
+- Chunk naming used stable `vendor-*` prefixes with content hashes.
+
+### After upgrade prep (Vite 8 / Rolldown)
+
+- The old object-form `manualChunks` is no longer valid and triggers a build-time error.
+- The migrated function-based chunk splitter keeps the same logical chunk groups and output naming
+  pattern (`vendor-react-*.js`, `vendor-ui-*.js`, `vendor-ai-*.js`).
+- **Current caveat:** full bundle output comparison is currently blocked by unrelated
+  `lucide-react` export errors in application source imports.
+
+## Bundle-level metrics snapshot
+
+| Metric                         | Pre-upgrade baseline                                                       | Post-upgrade (current run)                                                  |
+| ------------------------------ | -------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Total JS (dist snapshot proxy) | Dist folder snapshot: **8.9 MB**                                           | Not available (build blocked before emit)                                   |
+| Largest JS chunk               | `index-BQAvJkkD.js` — **260.49 kB** (81.11 kB gzip)                        | Not available (build blocked before emit)                                   |
+| Initial route payload          | Entry + shared vendor baseline led by `index`, `vendor-ui`, `vendor-react` | Expected same composition strategy; precise values pending successful build |
+
+## Follow-up required
+
+1. Resolve `lucide-react` import/export mismatches in app components.
+2. Re-run `pnpm build` and capture emitted chunk list from `dist/assets`.
+3. Update this document with post-upgrade measured values for:
+   - total emitted JS bytes,
+   - largest JS chunk,
+   - initial route payload bytes.

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,31 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const VENDOR_REACT_PACKAGES = [
+  'react',
+  'react-dom',
+  'react-router-dom',
+  '@dr.pogodin/react-helmet',
+];
+const VENDOR_UI_PACKAGES = ['framer-motion', 'lucide-react'];
+const VENDOR_AI_PACKAGES = ['@google/generative-ai'];
+
+function chunkByDependency(id) {
+  if (!id.includes('node_modules')) return;
+
+  if (VENDOR_REACT_PACKAGES.some(pkg => id.includes(`/node_modules/${pkg}/`))) {
+    return 'vendor-react';
+  }
+
+  if (VENDOR_UI_PACKAGES.some(pkg => id.includes(`/node_modules/${pkg}/`))) {
+    return 'vendor-ui';
+  }
+
+  if (VENDOR_AI_PACKAGES.some(pkg => id.includes(`/node_modules/${pkg}/`))) {
+    return 'vendor-ai';
+  }
+}
+
 export default defineConfig({
   plugins: [react()],
   base: '/', // Base public path when served in production
@@ -17,13 +42,15 @@ export default defineConfig({
     // Increase chunk size warning limit to 1MB (1000 KB)
     // This prevents warnings for larger bundles like the AI service and D3 visualizations
     chunkSizeWarningLimit: 1000,
-    rollupOptions: {
+
+    // Vite 8 (Rolldown) expects output.manualChunks to be a function.
+    // We intentionally keep our stable vendor chunk names so long-term bundle
+    // comparisons remain readable across releases.
+    rolldownOptions: {
       output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom', '@dr.pogodin/react-helmet'],
-          'vendor-ui': ['framer-motion', 'lucide-react'],
-          'vendor-ai': ['@google/generative-ai'],
-        },
+        // Caveat: package-path matching relies on node_modules path segments.
+        // Re-evaluate if dependency paths change (for example in PnP/virtual FS setups).
+        manualChunks: chunkByDependency,
       },
     },
   },


### PR DESCRIPTION
### Motivation

- Vite 8 replaces Rollup with Rolldown and requires `output.manualChunks` to be a function instead of the previous object mapping. 
- Preserve the existing vendor-group chunking (for readable, stable bundle comparisons) while making the config Vite 8-compatible. 

### Description

- Replaced object-form `build.rollupOptions.output.manualChunks` with a function-based splitter under `build.rolldownOptions.output.manualChunks` in `vite.config.js` and added `chunkByDependency` plus vendor package lists (`vendor-react`, `vendor-ui`, `vendor-ai`).
- Added explanatory inline comments in `vite.config.js` documenting the Vite 8 requirement, the retention rationale for vendor chunk names, and a caveat that path-based matching depends on `node_modules` layout. 
- Added migration notes at `docs/audits/vite8-chunk-migration-2026-04-16.md` that summarize before/after expectations, record bundle-level metric fields (total JS, largest chunk, initial route payload), and list follow-up steps for final measurement. 

### Testing

- `pnpm format:check` passed after applying formatting with `pnpm format`. 
- `pnpm lint` completed successfully. 
- Unit tests ran with `pnpm test:run` and all tests passed (`351 tests, 23 test files`). 
- `pnpm build` was attempted but failed during emit due to unrelated application import errors in `lucide-react` (missing exports like `Github`/`Linkedin`), so post-upgrade emitted chunk artifacts and final bundle metrics are pending until those import issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e116905fe88330a777c00e82549a76)