### PR TITLE
Add lucide import export checks and validate test icon mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --cache --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --cache --report-unused-disable-directives --max-warnings 0 && pnpm run check:lucide-imports",
     "lint:fix": "eslint . --cache --fix",
     "lint-staged": "lint-staged",
     "format": "prettier --write \"**/*.{js,jsx,json,css,html,md}\"",
@@ -29,7 +29,8 @@
     "prebuild": "pnpm run generate:geo",
     "audit:lighthouse:install-browser": "playwright install chromium",
     "audit:lighthouse": "node scripts/run-lighthouse-baseline.mjs",
-    "audit:baseline:full": "pnpm audit:baseline && pnpm audit:lighthouse"
+    "audit:baseline:full": "pnpm audit:baseline && pnpm audit:lighthouse",
+    "check:lucide-imports": "node scripts/check-lucide-imports.js"
   },
   "dependencies": {
     "@dr.pogodin/react-helmet": "^3.1.1",

--- a/scripts/check-lucide-imports.js
+++ b/scripts/check-lucide-imports.js
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as lucide from 'lucide-react';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const sourceDir = path.join(rootDir, 'src');
+const validExports = new Set(Object.keys(lucide));
+const sourceExtensions = new Set(['.js', '.jsx', '.ts', '.tsx']);
+
+const readSourceFiles = dir => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...readSourceFiles(absPath));
+      continue;
+    }
+
+    const ext = path.extname(entry.name);
+    if (sourceExtensions.has(ext)) files.push(absPath);
+  }
+
+  return files;
+};
+
+const parseLucideImports = content => {
+  const lucideImportPattern = /import\s*\{([^}]*)\}\s*from\s*['"]lucide-react['"];?/g;
+  const imports = [];
+  let match;
+
+  while ((match = lucideImportPattern.exec(content))) {
+    const names = match[1]
+      .split(',')
+      .map(name => name.trim())
+      .filter(Boolean)
+      .map(name => name.split(/\s+as\s+/)[0].trim());
+
+    imports.push(...names);
+  }
+
+  return imports;
+};
+
+const files = readSourceFiles(sourceDir);
+const inventory = new Map();
+const invalidImports = [];
+
+for (const filePath of files) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const importedIcons = parseLucideImports(content);
+  if (importedIcons.length === 0) continue;
+
+  const relPath = path.relative(rootDir, filePath).replace(/\\/g, '/');
+  inventory.set(relPath, importedIcons);
+
+  for (const iconName of importedIcons) {
+    if (!validExports.has(iconName)) invalidImports.push({ file: relPath, iconName });
+  }
+}
+
+console.log('Lucide import inventory:');
+for (const [file, icons] of [...inventory.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+  console.log(`- ${file}: ${icons.join(', ')}`);
+}
+
+if (invalidImports.length > 0) {
+  console.error('\nInvalid lucide-react imports detected:');
+  for (const violation of invalidImports) {
+    console.error(`- ${violation.file}: ${violation.iconName}`);
+  }
+  process.exit(1);
+}
+
+console.log(`\nPASS: Verified ${inventory.size} files against lucide-react@1.8.0 exports.`);

--- a/src/components/games/Minesweeper.test.jsx
+++ b/src/components/games/Minesweeper.test.jsx
@@ -5,13 +5,24 @@ import Minesweeper from './Minesweeper';
 import { ThemeProvider } from '../shared/ThemeProvider';
 
 // Mock dependencies
-vi.mock('lucide-react', () => ({
-  RotateCcw: () => <span data-testid="reset-icon">Reset</span>,
-  Trophy: () => <span data-testid="trophy-icon">Trophy</span>,
-  Flag: () => <span data-testid="flag-icon">Flag</span>,
-  Bomb: () => <span data-testid="bomb-icon">Bomb</span>,
-  Timer: () => <span data-testid="timer-icon">Timer</span>,
-}));
+vi.mock('lucide-react', async () => {
+  const ReactLib = await vi.importActual('react');
+  const lucide = await vi.importActual('lucide-react');
+  const mockIcon = (iconName, testId = `icon-${iconName.toLowerCase()}`) => {
+    if (!lucide[iconName]) {
+      throw new Error(`[lucide mock] ${iconName} is not exported by lucide-react.`);
+    }
+    return props => ReactLib.createElement('span', { ...props, 'data-testid': testId });
+  };
+
+  return {
+    RotateCcw: mockIcon('RotateCcw', 'reset-icon'),
+    Trophy: mockIcon('Trophy', 'trophy-icon'),
+    Flag: mockIcon('Flag', 'flag-icon'),
+    Bomb: mockIcon('Bomb', 'bomb-icon'),
+    Timer: mockIcon('Timer', 'timer-icon'),
+  };
+});
 
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual('framer-motion');

--- a/src/components/games/SnakeGame.test.jsx
+++ b/src/components/games/SnakeGame.test.jsx
@@ -5,12 +5,23 @@ import SnakeGame from './SnakeGame';
 import { ThemeProvider } from '../shared/ThemeProvider';
 
 // Mock dependencies
-vi.mock('lucide-react', () => ({
-  Play: () => <span data-testid="play-icon">Play</span>,
-  RotateCcw: () => <span data-testid="reset-icon">Reset</span>,
-  Trophy: () => <span data-testid="trophy-icon">Trophy</span>,
-  Pause: () => <span data-testid="pause-icon">Pause</span>,
-}));
+vi.mock('lucide-react', async () => {
+  const ReactLib = await vi.importActual('react');
+  const lucide = await vi.importActual('lucide-react');
+  const mockIcon = iconName => {
+    if (!lucide[iconName]) {
+      throw new Error(`[lucide mock] ${iconName} is not exported by lucide-react.`);
+    }
+    return props => ReactLib.createElement('span', { ...props, 'data-testid': `icon-${iconName.toLowerCase()}` });
+  };
+
+  return {
+    Play: mockIcon('Play'),
+    RotateCcw: mockIcon('RotateCcw'),
+    Trophy: mockIcon('Trophy'),
+    Pause: mockIcon('Pause'),
+  };
+});
 
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual('framer-motion');

--- a/src/components/pages/Playground.test.jsx
+++ b/src/components/pages/Playground.test.jsx
@@ -67,14 +67,26 @@ vi.mock('framer-motion', () => {
   };
 });
 
-vi.mock('lucide-react', () => ({
-  Code2: () => <div data-testid="icon-code2" />,
-  Palette: () => <div data-testid="icon-palette" />,
-  Copy: () => <div data-testid="icon-copy" />,
-  Check: () => <div data-testid="icon-check" />,
-  Play: () => <div data-testid="icon-play" />,
-  Terminal: () => <div data-testid="icon-terminal" />,
-}));
+vi.mock('lucide-react', async () => {
+  const ReactLib = await vi.importActual('react');
+  const lucide = await vi.importActual('lucide-react');
+  const mockIcon = iconName => {
+    if (!lucide[iconName]) {
+      throw new Error(`[lucide mock] ${iconName} is not exported by lucide-react.`);
+    }
+    return props =>
+      ReactLib.createElement('span', { ...props, 'data-testid': `icon-${iconName.toLowerCase()}` });
+  };
+
+  return {
+    Code2: mockIcon('Code2'),
+    Palette: mockIcon('Palette'),
+    Copy: mockIcon('Copy'),
+    Check: mockIcon('Check'),
+    Play: mockIcon('Play'),
+    Terminal: mockIcon('Terminal'),
+  };
+});
 
 vi.mock('../shared/SEOHead', () => ({
   default: () => <div data-testid="seo-head">SEO Head Mock</div>,


### PR DESCRIPTION
### Motivation
- Prevent runtime/test failures caused by renamed or removed icons from `lucide-react` by verifying imports early in CI. 
- Make unit tests more robust by ensuring mocked lucide icons reflect the actual installed exports so tests fail fast and clearly when icons change. 

### Description
- Add `scripts/check-lucide-imports.js`, a CI-safe script that inventories all `from 'lucide-react'` named imports under `src/` and validates each icon against the installed `lucide-react@1.8.0` exports. 
- Wire the check into `package.json` via a new `check:lucide-imports` script and append it to the existing `lint` pipeline. 
- Replace simple inline lucide mocks in `src/components/pages/Playground.test.jsx`, `src/components/games/Minesweeper.test.jsx`, and `src/components/games/SnakeGame.test.jsx` with factories that `vi.importActual('lucide-react')` and validate that each mocked icon name exists before returning a mock component. 
- Preserve existing test IDs used by assertions (e.g., `reset-icon`) for backwards compatibility while improving mock validation.

### Testing
- Ran `pnpm run format:check` and fixed formatting issues so Prettier check passes. (passed)
- Ran `pnpm run lint` which runs ESLint and the new `check:lucide-imports` script; the script listed the lucide import inventory and reported `PASS` for the current codebase. (passed)
- Executed targeted vitest runs for the modified tests with `pnpm vitest run src/components/games/Minesweeper.test.jsx src/components/games/SnakeGame.test.jsx src/components/pages/Playground.test.jsx` and verified all targeted tests passed. (passed)
- Executed the full test suite with `pnpm run test:run` and confirmed all tests passed (`23` files, `351` tests in the run). (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e117fe741083308e4f7de4c8ff389e)