### PR TITLE
ci: align Node matrix with Vite 8, run core gates, and fix runtime/dependency mismatches

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: "The Node.js version to use"
     required: false
-    default: "22"
+    default: "24"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Enforce pnpm-only lockfile policy
-        run: node scripts/check-package-manager-policy.js
-
       - name: Setup Environment
         uses: ./.github/actions/setup-env
+        with:
+          node-version: 24
 
       - name: Format check
         run: pnpm run format:check
+
+      - name: Enforce pnpm-only lockfile policy
+        run: pnpm run check:package-manager-policy
 
       - name: No-Aura tests
         run: pnpm run test:no-aura
@@ -57,7 +59,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20, 22, 23]
+        node-version: [20.19.0, 22.12.0, 24]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -79,6 +81,8 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env
+        with:
+          node-version: 24
 
       - name: Build
         run: pnpm run build
@@ -92,6 +96,8 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env
+        with:
+          node-version: 24
 
       - name: Full Security tests
         run: pnpm run test:security-full

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing to this project.
 
 ## Setup
 
-1. Install **Node.js 20+**.
+1. Install **Node.js `^20.19.0 || >=22.12.0`** (Vite 8 compatible).
 2. Install **pnpm 9+** (required package manager):
 
    ```bash
@@ -37,3 +37,11 @@ This repository is **pnpm-only**.
 - For dependency changes, run `pnpm install` (or `pnpm add/remove ...`) and commit the resulting `pnpm-lock.yaml` updates.
 
 CI enforces this policy and will fail if `package-lock.json` exists.
+
+## CI Node.js support matrix
+
+The main CI workflow validates Node.js versions aligned with Vite 8 support:
+
+- `20.19.0`
+- `22.12.0`
+- `24.x` (recommended current line)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Welcome to the repository for my personal portfolio website. This project showca
 
 - **Framework**: React 19 + Vite
 - **Styling**: Tailwind CSS v4 + Framer Motion
-- **Runtime**: Node.js 20+ (for build/scripts)
+- **Runtime**: Node.js `^20.19.0 || >=22.12.0` (for build/scripts, aligned with Vite 8)
 - **AI**: Google Generative AI (Gemini)
 - **Python**: Pyodide (WebAssembly)
 - **Testing**: Vitest + React Testing Library
@@ -27,7 +27,7 @@ Welcome to the repository for my personal portfolio website. This project showca
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js `^20.19.0 || >=22.12.0`
 - pnpm 9+ (required package manager for installs, scripts, and lockfile updates)
 
 ### Installation
@@ -117,6 +117,7 @@ To ensure reliable, fast, and secure software delivery, the following pipeline o
 - **Strict SHA Pinning**: All GitHub Actions (including first-party actions like `actions/checkout`) are strictly pinned to 40-character commit SHAs to prevent malicious updates. The `.github/workflows/workflow-lint.yml` guardrail enforces this policy on every PR.
 - **Caching**: The `setup-env` composite action automatically caches the `pnpm` store via `actions/setup-node`, saving bandwidth and speeding up test executions.
 - **Fail-Fast Parallelism**: The CI workflow tests across multiple Node.js environments (`[20, 22]`) in parallel, using the `fail-fast: true` strategy to immediately stop the build when any environment fails, saving compute resources.
+- **Vite 8 Node Compatibility Matrix**: CI verifies test coverage on all supported Vite 8 Node.js lines: `20.19.0`, `22.12.0`, and `24.x` (recommended current line).
 - **Cross-Platform Matrix Builds**: The test job uses a matrix strategy to verify the application across multiple operating systems (`ubuntu-latest`, `windows-latest`, `macos-latest`), ensuring broad compatibility and catching platform-specific issues early.
 - **Concurrency control**: Workflow concurrency correctly cancels in-progress jobs for outdated commits on the same branch or PR.
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@dr.pogodin/react-helmet": "^3.1.1",
     "@google/generative-ai": "^0.24.1",
     "framer-motion": "^12.38.0",
-    "lucide-react": "1.8.0",
+    "lucide-react": "0.577.0",
     "prismjs": "^1.30.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react:
-        specifier: 1.8.0
-        version: 1.8.0(react@19.2.5)
+        specifier: 0.577.0
+        version: 0.577.0(react@19.2.5)
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -2304,8 +2304,8 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-  lucide-react@1.8.0:
-    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
+  lucide-react@0.577.0:
+    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -5720,7 +5720,7 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lucide-react@1.8.0(react@19.2.5):
+  lucide-react@0.577.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 

--- a/src/components/games/SnakeGame.test.jsx
+++ b/src/components/games/SnakeGame.test.jsx
@@ -12,7 +12,8 @@ vi.mock('lucide-react', async () => {
     if (!lucide[iconName]) {
       throw new Error(`[lucide mock] ${iconName} is not exported by lucide-react.`);
     }
-    return props => ReactLib.createElement('span', { ...props, 'data-testid': `icon-${iconName.toLowerCase()}` });
+    return props =>
+      ReactLib.createElement('span', { ...props, 'data-testid': `icon-${iconName.toLowerCase()}` });
   };
 
   return {


### PR DESCRIPTION
### Motivation
- Ensure the CI Node matrix matches Vite 8 supported Node.js runtimes and run the repo's core gates after migrating to Vite 8.  
- Fix cross-runtime/path/env discrepancies discovered while validating the pipeline (package manager check ordering and default Node version for the shared setup action).  
- Resolve dependency/lockfile drift uncovered during the production build so builds succeed under the new toolchain.

### Description
- Updated `.github/workflows/ci.yml` to test on Node lines supported by Vite 8 (`20.19.0`, `22.12.0`, `24`) and set build/lint/security jobs to run with Node `24` for consistency.  
- Moved the pnpm lockfile policy check to run after environment setup and changed it to run via `pnpm run check:package-manager-policy` to avoid cross-runtime execution issues.  
- Updated the composite action default Node version in `.github/actions/setup-env/action.yml` from `22` to `24`.  
- Documented the supported Node matrix in `README.md` and `CONTRIBUTING.md` and clarified the runtime requirement as `^20.19.0 || >=22.12.0` (Vite 8-compatible).  
- Fixed a dependency/lockfile mismatch by aligning `lucide-react` to `0.577.0` in `package.json` and `pnpm-lock.yaml` to match the icons actually imported by the codebase.  
- Applied a small Prettier formatting change in `src/components/games/SnakeGame.test.jsx` to satisfy format checks.

### Testing
- Ran `pnpm install --frozen-lockfile` to validate lockfile resolution (succeeded).  
- Ran formatting checks with `pnpm run format:check` (succeeded).  
- Ran lint including the lucide import verifier with `pnpm run lint` (succeeded after aligning `lucide-react`).  
- Ran unit tests with `pnpm run test:run` (all tests passed in final validation).  
- Performed production build with `pnpm run build` (initial build failed due to `lucide-react` mismatch, fixed by aligning dependency; final build succeeded).  
- Executed security and quality gates `pnpm run test:security-full`, `pnpm run test:python-runner-stdout`, and `pnpm run test:pyodide-loader-retry` (all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11ac196488330a6aa695333774f21)