### PR TITLE
📚 Docs: Fixed broken markdown links in agent documentation

### DIFF
--- a/.agents/skills/accessibility/SKILL.md
+++ b/.agents/skills/accessibility/SKILL.md
@@ -435,6 +435,5 @@ See the [screen reader commands reference](references/A11Y-PATTERNS.md#screen-re
 - [WCAG 2.2 Quick Reference](https://www.w3.org/WAI/WCAG22/quickref/)
 - [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/)
 - [Deque axe Rules](https://dequeuniversity.com/rules/axe/)
-- [Web Quality Audit](../web-quality-audit/SKILL.md)
 - [WCAG criteria reference](references/WCAG.md)
 - [Accessibility code patterns](references/A11Y-PATTERNS.md)

--- a/.agents/skills/playwright-best-practices/advanced/network-advanced.md
+++ b/.agents/skills/playwright-best-practices/advanced/network-advanced.md
@@ -398,8 +398,8 @@ Use `context.setOffline(true/false)` to simulate network connectivity changes.
 
 > **For comprehensive offline testing patterns:**
 >
-> - **Network failure simulation** (error recovery, graceful degradation): See [error-testing.md](error-testing.md#offline-testing)
-> - **Offline-first/PWA testing** (service workers, caching, background sync): See [service-workers.md](service-workers.md#offline-testing)
+> - **Network failure simulation** (error recovery, graceful degradation): See [error-testing.md](../debugging/error-testing.md#offline-testing)
+> - **Offline-first/PWA testing** (service workers, caching, background sync): See [service-workers.md](../browser-apis/service-workers.md#offline-testing)
 
 ### Network Throttling Fixture
 

--- a/.agents/skills/playwright-best-practices/browser-apis/service-workers.md
+++ b/.agents/skills/playwright-best-practices/browser-apis/service-workers.md
@@ -254,7 +254,7 @@ test("cache updates on new version", async ({ page }) => {
 
 ## Offline Testing
 
-This section covers **offline-first apps (PWAs)** that are designed to work offline using service workers, caching, and background sync. For testing **unexpected network failures** (error recovery, graceful degradation), see [error-testing.md](error-testing.md#offline-testing).
+This section covers **offline-first apps (PWAs)** that are designed to work offline using service workers, caching, and background sync. For testing **unexpected network failures** (error recovery, graceful degradation), see [error-testing.md](../debugging/error-testing.md#offline-testing).
 
 ### Simulating Offline Mode
 
@@ -498,7 +498,7 @@ test("sync event fires when online", async ({ context, page }) => {
 
 ## Related References
 
-- **Network Failures**: See [error-testing.md](error-testing.md#offline-testing) for unexpected network failure patterns
+- **Network Failures**: See [error-testing.md](../debugging/error-testing.md#offline-testing) for unexpected network failure patterns
 - **Browser APIs**: See [browser-apis.md](browser-apis.md) for permissions
 - **Network Mocking**: See [network-advanced.md](../advanced/network-advanced.md) for network interception
 - **Browser Extensions**: See [browser-extensions.md](../testing-patterns/browser-extensions.md) for extension service worker patterns

--- a/.agents/skills/playwright-best-practices/debugging/error-testing.md
+++ b/.agents/skills/playwright-best-practices/debugging/error-testing.md
@@ -162,7 +162,7 @@ test("handles failure during request", async ({ page }) => {
 
 ## Offline Testing
 
-This section covers **unexpected network failures** and error recovery. For **offline-first apps (PWAs)** with service workers, caching, and background sync, see [service-workers.md](service-workers.md#offline-testing).
+This section covers **unexpected network failures** and error recovery. For **offline-first apps (PWAs)** with service workers, caching, and background sync, see [service-workers.md](../browser-apis/service-workers.md#offline-testing).
 
 ### Go Offline During Session
 

--- a/.agents/skills/playwright-best-practices/debugging/flaky-tests.md
+++ b/.agents/skills/playwright-best-practices/debugging/flaky-tests.md
@@ -199,7 +199,7 @@ await responsePromise;
 await expect(page.locator(".data-row")).toHaveCount(10);
 ```
 
-> **For comprehensive waiting strategies** (navigation, element state, network, polling with `toPass()`), see [assertions-waiting.md](assertions-waiting.md#waiting-strategies).
+> **For comprehensive waiting strategies** (navigation, element state, network, polling with `toPass()`), see [assertions-waiting.md](../core/assertions-waiting.md#waiting-strategies).
 
 **Problem: Complex async state**
 

--- a/.agents/skills/playwright-best-practices/infrastructure-ci-cd/performance.md
+++ b/.agents/skills/playwright-best-practices/infrastructure-ci-cd/performance.md
@@ -128,7 +128,7 @@ jobs:
 
 Avoid logging in for every test. Use setup projects with storage state to authenticate once and reuse the session.
 
-> **For authentication patterns** (storage state, multiple auth states, setup projects), see [fixtures-hooks.md](fixtures-hooks.md#authentication-patterns).
+> **For authentication patterns** (storage state, multiple auth states, setup projects), see [fixtures-hooks.md](../core/fixtures-hooks.md#authentication-patterns).
 
 ### Reuse Page State (serial only — trade-off with isolation)
 

--- a/.agents/skills/seo/SKILL.md
+++ b/.agents/skills/seo/SKILL.md
@@ -20,7 +20,7 @@ Search ranking factors (approximate influence):
 | Content quality & relevance | ~40% | Partial (structure) |
 | Backlinks & authority | ~25% | ✗ |
 | Technical SEO | ~15% | ✓ |
-| Page experience (Core Web Vitals) | ~10% | See [Core Web Vitals](../core-web-vitals/SKILL.md) |
+| Page experience (Core Web Vitals) | ~10% | See Core Web Vitals |
 | On-page SEO | ~10% | ✓ |
 
 ---
@@ -509,5 +509,3 @@ body {
 
 - [Google Search Central](https://developers.google.com/search)
 - [Schema.org](https://schema.org/)
-- [Core Web Vitals](../core-web-vitals/SKILL.md)
-- [Web Quality Audit](../web-quality-audit/SKILL.md)

--- a/.agents/skills/vercel-react-best-practices/AGENTS.md
+++ b/.agents/skills/vercel-react-best-practices/AGENTS.md
@@ -112,7 +112,7 @@ Waterfalls are the #1 performance killer. Each sequential await adds full networ
 
 When a branch uses `await` for a flag or remote value and also requires a **cheap synchronous** condition (local props, request metadata, already-loaded state), evaluate the cheap condition **first**. Otherwise you pay for the async call even when the compound condition can never be true.
 
-This is a specialization of [Defer Await Until Needed](./async-defer-await.md) for `flag && cheapCondition` style checks.
+This is a specialization of [Defer Await Until Needed](./rules/async-defer-await.md) for `flag && cheapCondition` style checks.
 
 **Incorrect:**
 
@@ -215,7 +215,7 @@ async function updateResource(resourceId: string, userId: string) {
 
 This optimization is especially valuable when the skipped branch is frequently taken, or when the deferred operation is expensive.
 
-For `await getFlag()` combined with a cheap synchronous guard (`flag && someCondition`), see [Check Cheap Conditions Before Async Flags](./async-cheap-condition-before-await.md).
+For `await getFlag()` combined with a cheap synchronous guard (`flag && someCondition`), see [Check Cheap Conditions Before Async Flags](./rules/async-cheap-condition-before-await.md).
 
 ### 1.3 Dependency-Based Parallelization
 
@@ -829,7 +829,7 @@ Safe exceptions:
 
 - Process-wide singletons that do not store request- or user-specific mutable data
 
-For static assets and config, see [Hoist Static I/O to Module Level](./server-hoist-static-io.md).
+For static assets and config, see [Hoist Static I/O to Module Level](./rules/server-hoist-static-io.md).
 
 ### 3.4 Cross-Request LRU Caching
 

--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -89,3 +89,12 @@
 - Audited codebase documentation for missing JSDoc/TSDoc comments on exported functions.
 - Verified that all exported functions and constants in the `src/` directory are already properly documented.
 - Verified no broken links in `docs/` and `README.md`.
+- **Checked and Fixed Broken Links**:
+  - Removed broken link `../web-quality-audit/SKILL.md` from `.agents/skills/accessibility/SKILL.md` and `.agents/skills/seo/SKILL.md`.
+  - Removed broken link `../core-web-vitals/SKILL.md` from `.agents/skills/seo/SKILL.md`.
+  - Fixed relative links in `.agents/skills/playwright-best-practices/advanced/network-advanced.md` pointing to `error-testing.md` and `service-workers.md`.
+  - Fixed relative link in `.agents/skills/playwright-best-practices/browser-apis/service-workers.md` pointing to `error-testing.md`.
+  - Fixed relative link in `.agents/skills/playwright-best-practices/debugging/error-testing.md` pointing to `service-workers.md`.
+  - Fixed relative link in `.agents/skills/playwright-best-practices/debugging/flaky-tests.md` pointing to `assertions-waiting.md`.
+  - Fixed relative link in `.agents/skills/playwright-best-practices/infrastructure-ci-cd/performance.md` pointing to `fixtures-hooks.md`.
+  - Fixed relative links in `.agents/skills/vercel-react-best-practices/AGENTS.md` pointing to `./async-defer-await.md`, `./async-cheap-condition-before-await.md`, and `./server-hoist-static-io.md`.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-18</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
* Fixed broken relative link paths in Playwright and Vercel React agent documentation directories.
* Removed invalid references to missing web-quality-audit and core-web-vitals skill documentation.
* Verified fix through the complete local testing and build suite.
* Logged changes to .jules/docs-progress.md.

---
*PR created automatically by Jules for task [18106926153043046829](https://jules.google.com/task/18106926153043046829) started by @saint2706*