### PR TITLE
📚 Docs: Remove broken Playwright docs links

### DIFF
--- a/.agents/skills/playwright-best-practices/testing-patterns/browser-extensions.md
+++ b/.agents/skills/playwright-best-practices/testing-patterns/browser-extensions.md
@@ -8,7 +8,6 @@
 4. [Background Script Testing](#background-script-testing)
 5. [Content Script Testing](#content-script-testing)
 6. [Extension APIs](#extension-apis)
-7. [Cross-Browser Testing](#cross-browser-testing)
 
 ## Setup & Configuration
 

--- a/.agents/skills/playwright-best-practices/testing-patterns/performance-testing.md
+++ b/.agents/skills/playwright-best-practices/testing-patterns/performance-testing.md
@@ -6,8 +6,7 @@
 2. [Performance Metrics](#performance-metrics)
 3. [Performance Budgets](#performance-budgets)
 4. [Lighthouse Integration](#lighthouse-integration)
-5. [Performance Fixtures](#performance-fixtures)
-6. [CI Performance Monitoring](#ci-performance-monitoring)
+5. [CI Performance Monitoring](#ci-performance-monitoring)
 
 ## Core Web Vitals
 

--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -98,3 +98,7 @@
   - Fixed relative link in `.agents/skills/playwright-best-practices/debugging/flaky-tests.md` pointing to `assertions-waiting.md`.
   - Fixed relative link in `.agents/skills/playwright-best-practices/infrastructure-ci-cd/performance.md` pointing to `fixtures-hooks.md`.
   - Fixed relative links in `.agents/skills/vercel-react-best-practices/AGENTS.md` pointing to `./async-defer-await.md`, `./async-cheap-condition-before-await.md`, and `./server-hoist-static-io.md`.
+
+## 2026-04-18
+
+- Removed broken table of contents links `#performance-fixtures` and `#cross-browser-testing` from Playwright best practices documentation.


### PR DESCRIPTION
Removed broken `#performance-fixtures` and `#cross-browser-testing` links from the Playwright testing patterns documentation files. Documented progress in `.jules/docs-progress.md` and verified with the test suite.

---
*PR created automatically by Jules for task [6848160381893588166](https://jules.google.com/task/6848160381893588166) started by @saint2706*