### PR TITLE
🛡️ Sentinel: Fix AST node injection in react-markdown custom renderers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,8 @@ Resolved High severity vulnerability in a deep transitive dependency of Lighthou
 - Updated `src/services/ai.js` to correctly truncate UTF-16 strings using array spreading (`[...str].slice(...)`) to prevent splitting surrogate pairs, which can cause DoS or URI encoding errors.
 - Verified safe JSON serialization in `SEOHead.jsx`.
 - Verified strict CSP and secure attribute ordering in `ChatInterface.jsx`.
+
+### Security Improvement: React-Markdown DOM Attribute Injection
+
+- **Vulnerability / Warning**: `react-markdown` passes an AST `node` object to custom renderers. When `...rest` is spread onto DOM elements (like `<a>` or `<img>`), this object is passed as an attribute (`node="[object Object]"`), which causes React console warnings and could theoretically be manipulated if the AST structure is compromised.
+- **Fix**: Updated `LinkRenderer` and `ImageRenderer` in `src/components/shared/ChatInterface.jsx` to explicitly destructure `node: _node` from `rest`, ensuring the AST node is never spread into the DOM elements.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-19</lastmod>
+    <lastmod>2026-04-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-19</lastmod>
+    <lastmod>2026-04-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-19</lastmod>
+    <lastmod>2026-04-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-19</lastmod>
+    <lastmod>2026-04-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-19</lastmod>
+    <lastmod>2026-04-22</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-19</lastmod>
+    <lastmod>2026-04-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-19</lastmod>
+    <lastmod>2026-04-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/components/shared/ChatInterface.jsx
+++ b/src/components/shared/ChatInterface.jsx
@@ -94,7 +94,7 @@ const QUICK_REPLIES = [
  * @returns {JSX.Element} Either a safe anchor tag or plain text span
  */
 // ⚡ Bolt: Wrapped LinkRenderer in React.memo to prevent unnecessary re-rendering of expensive Markdown nodes.
-const LinkRenderer = React.memo(({ href, children, ...rest }) => {
+const LinkRenderer = React.memo(({ href, children, node: _node, ...rest }) => {
   // Security: Only allow http, https, and mailto protocols to prevent XSS (e.g., javascript:)
   const isValidHref = isSafeHref(href);
 
@@ -129,7 +129,7 @@ LinkRenderer.displayName = 'LinkRenderer';
  * @returns {JSX.Element} Either the image tag or a placeholder/warning
  */
 // ⚡ Bolt: Wrapped ImageRenderer in React.memo to prevent unnecessary re-rendering of expensive Markdown nodes.
-const ImageRenderer = React.memo(({ src, alt, ...rest }) => {
+const ImageRenderer = React.memo(({ src, alt, node: _node, ...rest }) => {
   // Security: Validate image source to prevent dangerous protocols (e.g., javascript:)
   // Uses isSafeImageSrc which only allows http/https (not mailto: which doesn't make sense for images)
   const isValidSrc = isSafeImageSrc(src);


### PR DESCRIPTION
This PR addresses a React "unknown prop" warning and potential security risk caused by `react-markdown` passing AST nodes to custom renderers.

When spreading `...rest` into the `<a>` and `<img>` components inside `ChatInterface.jsx`, the internal AST object `node` was serialized and injected into the DOM as `node="[object Object]"`. This has been resolved by explicitly destructuring and ignoring the `node` prop.

---
*PR created automatically by Jules for task [5481737861288903645](https://jules.google.com/task/5481737861288903645) started by @saint2706*