### PR TITLE
🎨 Picasso: [Accessibility improvement] Add aria-hidden to decorative icons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -76,3 +76,4 @@ Implements various UX and accessibility enhancements across the application, foc
 - Added `aria-hidden="true"` to `ArrowUp` icon within `ScrollToTop` button to improve accessibility by hiding decorative icons from screen readers when the parent element already provides an `aria-label`.
 - Added explicit `aria-label` to the Snake Game resume button to improve accessibility and screen reader support.
 - Added `focus-visible` styling to the mobile menu and settings buttons in `Navbar.jsx` to ensure keyboard accessibility.
+>> Added aria-hidden=true to decorative icons nested inside accessible buttons/chips to prevent redundant screen reader announcements.

--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -76,4 +76,4 @@ Implements various UX and accessibility enhancements across the application, foc
 - Added `aria-hidden="true"` to `ArrowUp` icon within `ScrollToTop` button to improve accessibility by hiding decorative icons from screen readers when the parent element already provides an `aria-label`.
 - Added explicit `aria-label` to the Snake Game resume button to improve accessibility and screen reader support.
 - Added `focus-visible` styling to the mobile menu and settings buttons in `Navbar.jsx` to ensure keyboard accessibility.
->> Added aria-hidden=true to decorative icons nested inside accessible buttons/chips to prevent redundant screen reader announcements.
+  > > Added aria-hidden=true to decorative icons nested inside accessible buttons/chips to prevent redundant screen reader announcements.

--- a/src/components/pages/Blog.jsx
+++ b/src/components/pages/Blog.jsx
@@ -390,7 +390,7 @@ const Blog = React.memo(() => {
               variant="secondary"
               className="gap-1 hover:-translate-y-0.5"
             >
-              <ChevronLeft size={18} /> Prev
+              <ChevronLeft size={18} aria-hidden="true" /> Prev
             </ThemedButton>
 
             <div className="flex items-center gap-2">
@@ -416,7 +416,7 @@ const Blog = React.memo(() => {
               variant="secondary"
               className="gap-1 hover:-translate-y-0.5"
             >
-              Next <ChevronRight size={18} />
+              Next <ChevronRight size={18} aria-hidden="true" />
             </ThemedButton>
           </motion.div>
         )}

--- a/src/components/pages/NotFound.jsx
+++ b/src/components/pages/NotFound.jsx
@@ -277,7 +277,7 @@ const NotFound = () => {
               )}
               style={isLiquid ? undefined : { boxShadow: 'var(--nb-shadow)' }}
             >
-              <Home size={20} />
+              <Home size={20} aria-hidden="true" />
               Go Home
             </ThemedButton>
             <ThemedButton
@@ -290,7 +290,7 @@ const NotFound = () => {
               )}
               style={isLiquid ? undefined : { boxShadow: 'var(--nb-shadow)' }}
             >
-              <ArrowLeft size={20} />
+              <ArrowLeft size={20} aria-hidden="true" />
               Go Back
             </ThemedButton>
           </motion.div>
@@ -317,7 +317,7 @@ const NotFound = () => {
                 )}
                 style={isLiquid ? undefined : { boxShadow: '2px 2px 0 var(--color-border)' }}
               >
-                <Compass size={16} className="inline mr-2" />
+                <Compass size={16} className="inline mr-2" aria-hidden="true" />
                 Quick Navigation
               </ThemedChip>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-3">


### PR DESCRIPTION
🎨 Picasso: [Accessibility improvement] Add aria-hidden to decorative icons

Added `aria-hidden="true"` to decorative Lucide icons nested inside buttons and chips that already have accessible text or labels. This prevents screen readers from making redundant announcements.

Modified files:
- `src/components/pages/NotFound.jsx` (Home, ArrowLeft, Compass)
- `src/components/pages/Blog.jsx` (ChevronLeft, ChevronRight)

---
*PR created automatically by Jules for task [6050245069620402530](https://jules.google.com/task/6050245069620402530) started by @saint2706*