### PR TITLE
🛡️ Sentinel: Fix PostCSS XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,3 +38,9 @@ Resolved High severity vulnerability in a deep transitive dependency of Lighthou
 
 - **Vulnerability / Warning**: `react-markdown` passes an AST `node` object to custom renderers. When `...rest` is spread onto DOM elements (like `<a>` or `<img>`), this object is passed as an attribute (`node="[object Object]"`), which causes React console warnings and could theoretically be manipulated if the AST structure is compromised.
 - **Fix**: Updated `LinkRenderer` and `ImageRenderer` in `src/components/shared/ChatInterface.jsx` to explicitly destructure `node: _node` from `rest`, ensuring the AST node is never spread into the DOM elements.
+
+### 2026-04-24
+
+- **[SEC-DEP] PostCSS XSS via Unescaped <style> (GHSA-qx2v-qp2m-jg93)**:
+  - Discovered a Moderate severity vulnerability in `postcss@8.5.8` via `pnpm audit`.
+  - Upgraded `postcss` to `8.5.10` using `pnpm install postcss@8.5.10`.

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lighthouse": "^13.0.3",
     "lint-staged": "^16.3.3",
     "playwright": "^1.58.2",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.10",
     "prettier": "^3.8.1",
     "rss-parser": "^3.13.0",
     "tailwindcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 4.1.4(vitest@4.1.4)
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.4.27(postcss@8.5.9)
+        version: 10.4.27(postcss@8.5.10)
       chrome-launcher:
         specifier: ^1.2.1
         version: 1.2.1
@@ -111,8 +111,8 @@ importers:
         specifier: ^1.58.2
         version: 1.59.1
       postcss:
-        specifier: ^8.5.8
-        version: 8.5.9
+        specifier: ^8.5.10
+        version: 8.5.10
       prettier:
         specifier: ^3.8.1
         version: 3.8.2
@@ -2614,8 +2614,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -4193,7 +4193,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.9
+      postcss: 8.5.10
       tailwindcss: 4.2.2
 
   '@testing-library/dom@10.4.1':
@@ -4492,13 +4492,13 @@ snapshots:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
-  autoprefixer@10.4.27(postcss@8.5.9):
+  autoprefixer@10.4.27(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001787
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.9
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -6173,7 +6173,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.9:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -6844,7 +6844,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.10
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
This submission addresses a moderate XSS vulnerability reported in the `postcss` dependency (GHSA-qx2v-qp2m-jg93).

**Changes made:**
- Ran `pnpm audit` and discovered `postcss` version `8.5.8` is vulnerable to XSS via Unescaped `<style>` in its CSS Stringify Output.
- Fixed the vulnerability by upgrading `postcss` to the safe version `8.5.10` using `pnpm install postcss@8.5.10`. This correctly bumps the dependency and updates `pnpm-lock.yaml`.
- Appended findings and actions taken to `.jules/sentinel.md` as required by the Sentinel agent protocol.
- Executed full verification suite, ensuring `pnpm audit` now reports no vulnerabilities and all local lint/tests pass seamlessly.

---
*PR created automatically by Jules for task [1193217326129709374](https://jules.google.com/task/1193217326129709374) started by @saint2706*