### PR TITLE
fix: bind document.startViewTransition to fix broken navbar navigation

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-23</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/navigation/viewTransitionNavigate.ts
+++ b/src/navigation/viewTransitionNavigate.ts
@@ -25,7 +25,9 @@ export const VIEW_TRANSITION_NAVIGATION_ENABLED =
 const getStartViewTransition = () => {
   if (typeof document === 'undefined') return null;
   if (!('startViewTransition' in document)) return null;
-  return typeof document.startViewTransition === 'function' ? document.startViewTransition : null;
+  return typeof document.startViewTransition === 'function'
+    ? document.startViewTransition.bind(document)
+    : null;
 };
 
 /**


### PR DESCRIPTION
## Summary

- `getStartViewTransition()` in `viewTransitionNavigate.ts` was returning `document.startViewTransition` without binding it to `document`
- Calling it as a standalone function threw `Illegal invocation` in browsers that support the View Transitions API
- Because `event.preventDefault()` already fired before the error, all nav link clicks were silently swallowed — links appeared completely broken
- Fix: `.bind(document)` ensures the method is called with the correct `this` context

## Root cause

```ts
// Before (broken): unbound method reference
return typeof document.startViewTransition === 'function' ? document.startViewTransition : null;

// After (fixed): bound to document
return typeof document.startViewTransition === 'function'
  ? document.startViewTransition.bind(document)
  : null;
```

## Test plan

- [x] All 390 existing unit tests pass
- [x] Playwright end-to-end checks pass: desktop nav links navigate, mobile menu opens/closes, logo navigates home, settings modal opens, active link styling correct
- [x] `Illegal invocation` console error no longer appears

https://claude.ai/code/session_01P7xgYH655jwXWddkwgijuc

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7xgYH655jwXWddkwgijuc)_