### PR TITLE
fix: increase mobile menu dropdown opacity on liquid theme

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -363,6 +363,15 @@ const Navbar = React.memo(({ onOpenSettings }) => {
               exit={{ opacity: 0, y: -10 }}
               transition={{ duration: 0.2 }}
               className={`absolute right-4 top-full mt-3 w-64 md:hidden overflow-hidden ${mobileMenuCls}`}
+              style={
+                isLiquid
+                  ? {
+                      '--glass-bg': isLiquidDark
+                        ? 'rgba(44, 44, 46, 0.92)'
+                        : 'rgba(255, 255, 255, 0.92)',
+                    }
+                  : undefined
+              }
               ref={menuRef}
               role="dialog"
               aria-label="Navigation menu"


### PR DESCRIPTION
## Summary

- The mobile hamburger menu dropdown on the liquid theme appeared nearly transparent when opened
- Root cause: `lg-surface-2` (55% opacity glass + `backdrop-filter`) was rendered inside `lg-surface-1` (also has `backdrop-filter`), which creates an isolated compositing group — the child's `backdrop-filter` blurs the already-processed parent layer rather than the actual page content behind the dropdown
- Fix: override `--glass-bg` CSS variable directly on the dropdown element to 92% opacity (`rgba(255,255,255,0.92)` for light, `rgba(44,44,46,0.92)` for dark), making the background solidly visible regardless of how nested backdrop-filter stacking contexts resolve

## Test plan

- [ ] Open site on a mobile viewport (< 768px) with the **liquid** theme active
- [ ] Tap the hamburger menu button — dropdown should appear with a clearly visible, non-transparent background
- [ ] Switch to **liquid-dark** theme and repeat — dark dropdown should be equally opaque
- [ ] Switch to **neubrutalism** theme — dropdown should be unchanged (solid `bg-card`, no style prop applied)

https://claude.ai/code/session_0159G1o9vu5aGcMhJvrKoKyv

---
_Generated by [Claude Code](https://claude.ai/code/session_0159G1o9vu5aGcMhJvrKoKyv)_