### PR TITLE
feat: smooth radial-reveal theme switching from click origin

### DIFF
--- a/src/components/shared/SettingsModal.jsx
+++ b/src/components/shared/SettingsModal.jsx
@@ -50,7 +50,7 @@ const ThemeCard = ({ option, isActive, onClick }) => {
   return (
     <button
       type="button"
-      onClick={() => onClick(option.id)}
+      onClick={e => onClick(option.id, { x: e.clientX, y: e.clientY })}
       aria-pressed={isActive}
       aria-label={`Select ${option.label} theme`}
       className="settings-theme-card"

--- a/src/components/shared/ThemeProvider.jsx
+++ b/src/components/shared/ThemeProvider.jsx
@@ -29,9 +29,28 @@ export const ThemeProvider = ({ children }) => {
   }, []);
 
   const setTheme = useCallback(
-    nextTheme => {
+    (nextTheme, origin) => {
+      const root = document.documentElement;
+      const x = origin?.x ?? window.innerWidth / 2;
+      const y = origin?.y ?? window.innerHeight / 2;
+      root.style.setProperty('--vt-x', `${x}px`);
+      root.style.setProperty('--vt-y', `${y}px`);
+
       if (document.startViewTransition) {
-        document.startViewTransition(() => applyTheme(nextTheme));
+        root.style.setProperty(
+          '--vt-root-new-anim',
+          'vt-theme-reveal 0.55s cubic-bezier(0.22, 1, 0.36, 1) both'
+        );
+        root.style.setProperty('--vt-root-old-anim', 'none');
+
+        const transition = document.startViewTransition(() => applyTheme(nextTheme));
+
+        transition.finished.finally(() => {
+          root.style.removeProperty('--vt-root-new-anim');
+          root.style.removeProperty('--vt-root-old-anim');
+          root.style.removeProperty('--vt-x');
+          root.style.removeProperty('--vt-y');
+        });
       } else {
         applyTheme(nextTheme);
       }

--- a/src/components/shared/ThemeProvider.test.jsx
+++ b/src/components/shared/ThemeProvider.test.jsx
@@ -32,7 +32,10 @@ describe('ThemeProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     storage.safeGetLocalStorage.mockReturnValue(null);
-    document.startViewTransition = vi.fn(cb => { cb(); return { finished: Promise.resolve() }; });
+    document.startViewTransition = vi.fn(cb => {
+      cb();
+      return { finished: Promise.resolve() };
+    });
   });
 
   afterEach(() => {

--- a/src/components/shared/ThemeProvider.test.jsx
+++ b/src/components/shared/ThemeProvider.test.jsx
@@ -32,7 +32,7 @@ describe('ThemeProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     storage.safeGetLocalStorage.mockReturnValue(null);
-    document.startViewTransition = vi.fn(cb => cb());
+    document.startViewTransition = vi.fn(cb => { cb(); return { finished: Promise.resolve() }; });
   });
 
   afterEach(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -1289,7 +1289,16 @@
 
 /* ===== VIEW TRANSITION CHOREOGRAPHY ===== */
 
-/* --- Keyframes for page-content slide+fade --- */
+/* CSS vars on :root control which animation runs — inherited by ::view-transition-* pseudo-elements.
+   JS overrides these inline before theme transitions, then clears them after. */
+:root {
+  --vt-x: 50%;
+  --vt-y: 50%;
+  --vt-root-old-anim: vt-crossfade-out 0.3s ease both;
+  --vt-root-new-anim: vt-crossfade-in 0.3s ease both;
+}
+
+/* --- Page-content slide+fade --- */
 @keyframes vt-slide-up-in {
   from {
     opacity: 0;
@@ -1312,12 +1321,35 @@
   }
 }
 
+/* --- Root crossfade (default / page navigations) --- */
+@keyframes vt-crossfade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes vt-crossfade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+/* --- Theme switch: radial reveal from click point --- */
+@keyframes vt-theme-reveal {
+  from {
+    clip-path: circle(0% at var(--vt-x) var(--vt-y));
+  }
+  to {
+    clip-path: circle(150% at var(--vt-x) var(--vt-y));
+  }
+}
+
 @media (prefers-reduced-motion: no-preference) {
-  /* Default root crossfade */
-  ::view-transition-old(root),
+  /* Root uses CSS-var-driven animation — JS swaps vars for theme transitions */
+  ::view-transition-old(root) {
+    animation: var(--vt-root-old-anim);
+  }
+
   ::view-transition-new(root) {
-    animation-duration: 0.3s;
-    animation-timing-function: ease;
+    animation: var(--vt-root-new-anim);
   }
 
   /* Chrome header stays pinned — no animation */

--- a/src/index.css
+++ b/src/index.css
@@ -1323,13 +1323,21 @@
 
 /* --- Root crossfade (default / page navigations) --- */
 @keyframes vt-crossfade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes vt-crossfade-out {
-  from { opacity: 1; }
-  to { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 /* --- Theme switch: radial reveal from click point --- */


### PR DESCRIPTION
## Summary

- Theme transitions now use a **radial circle reveal** that expands from the exact pixel where the user clicked a theme card, powered by the View Transitions API and `clip-path: circle()`
- Click coordinates are passed from `SettingsModal` → `ThemeProvider.setTheme(theme, { x, y })`
- Before each theme transition, JS sets `--vt-x`/`--vt-y` and overrides `--vt-root-new-anim` inline on `:root`; the `::view-transition-new(root)` pseudo-element inherits these and runs the reveal keyframe
- After `transition.finished`, the inline overrides are cleaned up so page-navigation transitions continue using their existing crossfade/slide animations unaffected

## Test plan

- [ ] Open Settings modal and click each theme card — new theme should expand from the click point in a smooth circle
- [ ] Navigate between pages — slide-up-in / slide-down-out animations on `page-content` still work normally
- [ ] Verify fallback: on browsers without `document.startViewTransition`, theme applies instantly with no JS error
- [ ] Enable "prefers-reduced-motion" in OS/DevTools — all animations should be disabled

https://claude.ai/code/session_01GqbD4KhNQ8uubHG4gP7j6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqbD4KhNQ8uubHG4gP7j6T)_