### PR TITLE
📚 Docs: Fix broken TPGI color contrast checker link

### DIFF
--- a/.agents/skills/accessibility/references/WCAG.md
+++ b/.agents/skills/accessibility/references/WCAG.md
@@ -182,7 +182,7 @@
 | Lighthouse | Built into Chrome | DevTools → Lighthouse |
 | NVDA | Screen reader (Windows) | [nvaccess.org](https://www.nvaccess.org/) |
 | VoiceOver | Screen reader (Mac) | Built into macOS |
-| Colour Contrast Analyser | Desktop app | [tpgi.com](https://www.tpgi.com/color-contrast-checker/) |
+| Colour Contrast Analyser | Desktop app | [vispero.com](https://vispero.com/lp/color-contrast-checker/) |
 
 ## Sources
 

--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -103,3 +103,9 @@
 
 - Removed broken table of contents links `#performance-fixtures` and `#cross-browser-testing` from Playwright best practices documentation.
 - Removed duplicate/redundant JSDoc blocks in `src/services/ai.js` and `src/utils/seo.js`.
+
+## 2026-04-28
+
+- Audited documentation for broken links using `markdown-link-check`.
+- Replaced dead TPGI color contrast checker link with the valid Vispero landing page URL in `.agents/skills/accessibility/references/WCAG.md`.
+- Verified changes with standard local suite (`pnpm run build && pnpm run format:check && pnpm run lint && pnpm run test:run`) and cleaned up auto-generated `sitemap.xml` modifications to keep commits focused.


### PR DESCRIPTION
- Replaced dead TPGI color contrast checker link with the valid Vispero landing page URL in `.agents/skills/accessibility/references/WCAG.md`.
- Evaluated other potential false positive 403/Status: 0 errors from `markdown-link-check` and manually verified them to be valid.
- Logged task progress in `.jules/docs-progress.md`.

---
*PR created automatically by Jules for task [16410291421878579781](https://jules.google.com/task/16410291421878579781) started by @saint2706*