### PR TITLE
🧘‍♂️ Buddha: [GEO documentation] Added audit log to buddha-scroll.md

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -331,3 +331,8 @@ Audited the codebase for Core Web Vitals (LCP, CLS, INP), structured data (JSON-
 1.  **[SEO][GEO] Audited codebase**:
     - Confirmed `llms.txt`, `robots.txt`, structured data (JSON-LD), `dangerouslySetInnerHTML` sanitization, and semantic HTML hierarchy meet requirements.
     - Confirmed LCP and priority elements were optimized. No additional code changes were necessary as the codebase already satisfies all Buddha persona constraints.
+>> Audit completed. Verified that `<h2>` is correctly used in `index.html` <noscript> fallback.
+>> Verified `sitemap.xml` and `llms.txt` using `pnpm run generate:geo`.
+>> H1-H6 semantic structure is intact across all pages.
+>> JSON-LD is correctly sanitized using safeJSONStringify to prevent XSS.
+>> Image priority eager loading is in place for LCP (Hero) element and eager images on projects, lazy otherwise.


### PR DESCRIPTION
Following the daily process of the Buddha persona, conducted an audit on Core Web Vitals, JSON-LD, llms.txt, and semantic HTML tags. Verified everything is intact and correct, logging the findings to `.jules/buddha-scroll.md`.

---
*PR created automatically by Jules for task [17589820858023791953](https://jules.google.com/task/17589820858023791953) started by @saint2706*