### PR TITLE
🧪 Testing: Add unit tests for gameThemeStyles utility

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/components/games/gameThemeStyles.test.js
+++ b/src/components/games/gameThemeStyles.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { getGameThemeStyles } from './gameThemeStyles';
+
+describe('getGameThemeStyles', () => {
+  it('returns liquid theme styles when isLiquid is true', () => {
+    const styles = getGameThemeStyles(true);
+    expect(styles.scoreboard).toContain('lg-surface-2');
+    expect(styles.scoreboard).toContain('rounded-2xl');
+    expect(styles.separator).toContain('w-px');
+    expect(styles.style.raised).toBeUndefined();
+    expect(styles.style.board).toBeUndefined();
+    expect(styles.style.tile).toBeUndefined();
+    expect(styles.style.tileActive).toBeUndefined();
+  });
+
+  it('returns neubrutalism theme styles when isLiquid is false', () => {
+    const styles = getGameThemeStyles(false);
+    expect(styles.scoreboard).toContain('border-[3px]');
+    expect(styles.separator).toContain('w-[3px]');
+    expect(styles.style.raised).toBeDefined();
+    expect(styles.style.board).toBeDefined();
+    expect(styles.style.tile).toBeDefined();
+    expect(styles.style.tileActive).toBeDefined();
+  });
+
+  it('filters out falsy values in join correctly', () => {
+    // Tests join internally
+    const styles = getGameThemeStyles(true);
+    expect(styles.scoreboard).not.toContain('undefined');
+    expect(styles.scoreboard).not.toContain('null');
+    expect(styles.scoreboard).not.toContain('false');
+  });
+});


### PR DESCRIPTION
As the "Testing" 🧪 specialist, I identified a gap in coverage for the `getGameThemeStyles` utility and added comprehensive unit tests to ensure its logic remains correct across themes (liquid vs neubrutalism). Tests are fast and robust, directly verifying correct application of tailwind classes and style properties.

---
*PR created automatically by Jules for task [12219032820088240340](https://jules.google.com/task/12219032820088240340) started by @saint2706*