### PR TITLE
📚 Docs: Audited broken links and updated docs progress

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -109,3 +109,10 @@
 - Audited documentation for broken links using `markdown-link-check`.
 - Replaced dead TPGI color contrast checker link with the valid Vispero landing page URL in `.agents/skills/accessibility/references/WCAG.md`.
 - Verified changes with standard local suite (`pnpm run build && pnpm run format:check && pnpm run lint && pnpm run test:run`) and cleaned up auto-generated `sitemap.xml` modifications to keep commits focused.
+
+## 2026-04-29
+
+- Audited documentation for broken links using `markdown-link-check`.
+- Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
+- Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
+- Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.


### PR DESCRIPTION
I have audited the documentation for broken links using `markdown-link-check`. The tool identified `https://play.tailwindcss.com` as a dead link (Status: 0), but manual verification confirmed this is a false positive due to network constraints (the site is live and returns HTTP 200). Therefore, no functional changes to the codebase were required.

I have updated the `.jules/docs-progress.md` file to track this audit as per the instructions, and verified that the workspace passes the standard local suite (`build`, `lint`, `format:check`, `test:run`). All automatically generated build artifacts (`public/sitemap.xml` and `public/llms.txt`) have been correctly restored to keep the commit focused.

---
*PR created automatically by Jules for task [12477321625327705159](https://jules.google.com/task/12477321625327705159) started by @saint2706*