### PR TITLE
📚 Docs: Audit and verify no broken links

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,3 +116,4 @@
 - Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
 - Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
 - Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.
+- Verified no broken links in codebase docs using markdown-link-check.


### PR DESCRIPTION
Audited the project's documentation using markdown-link-check to ensure no broken links exist in markdown files. No broken links were found, and the audit progress was documented.

---
*PR created automatically by Jules for task [13120961695246517553](https://jules.google.com/task/13120961695246517553) started by @saint2706*