### PR TITLE
🔄 CI/CD: Enforce fail-fast dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         run: pnpm run lint
 
   test:
+    needs: [lint]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -73,6 +74,7 @@ jobs:
         run: pnpm run test:run
 
   build:
+    needs: [lint]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -88,6 +90,7 @@ jobs:
         run: pnpm run build
 
   security:
+    needs: [lint]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -42,6 +42,7 @@ jobs:
         run: ~/.local/bin/actionlint
 
   workflow-security:
+    needs: [actionlint]
     name: Check workflow security guardrails
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.jules/ci-cd.md
+++ b/.jules/ci-cd.md
@@ -37,3 +37,8 @@
 
 - **Update**: Merged `generate` and `commit` jobs into a single `sync` job in `.github/workflows/sync-blogs.yml`.
 - **Why**: Eliminates the sequential `needs: generate` constraint and removes the overhead of uploading and downloading artifacts, bypassing a redundant runner spin-up to reduce pipeline duration.
+
+## Fail Fast Dependencies
+
+- **Update**: Added `needs: [lint]` to `test`, `build`, and `security` jobs in `.github/workflows/ci.yml`. Added `needs: [actionlint]` to `workflow-security` job in `.github/workflows/workflow-lint.yml`.
+- **Why**: Enforces a fail-fast mechanism. If linting fails, it prevents subsequent resource-intensive jobs from running, saving compute resources and reducing overall pipeline time on broken code.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
- Added `needs: [lint]` to the `test`, `build`, and `security` jobs in `.github/workflows/ci.yml`.
- Added `needs: [actionlint]` to the `workflow-security` job in `.github/workflows/workflow-lint.yml`.
- Appended fail-fast pipeline optimization documentation to `.jules/ci-cd.md`.

---
*PR created automatically by Jules for task [13835917044072152559](https://jules.google.com/task/13835917044072152559) started by @saint2706*