### PR TITLE
🎨 Picasso: Remove redundant native tooltips from icon buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -5,3 +5,4 @@
 
 > > Added `aria-hidden="true"` to icon components if the parent button already has an `aria-label` or visible text to improve screen-reader accessibility and prevent redundant reading.
 > > Added title attributes to icon buttons for better tooltip UX and accessibility
+> > Removed redundant `title` attributes on elements that already implement custom UI tooltips (via inner span with hover states) to avoid the double-tooltip effect.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://saint2706.github.io/</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/projects</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/resume</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/blog</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/contact</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/games</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://saint2706.github.io/playground</loc>
-    <lastmod>2026-04-29</lastmod>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -130,7 +130,6 @@ const Footer = React.memo(() => {
                       : { boxShadow: 'var(--nb-shadow)', '--invert-text': '#ffffff' }
                   }
                   aria-label="Visit GitHub"
-                  title="Visit GitHub"
                 >
                   <Github size={24} aria-hidden="true" />
                   <span
@@ -156,7 +155,6 @@ const Footer = React.memo(() => {
                       : { boxShadow: 'var(--nb-shadow)', '--invert-text': '#ffffff' }
                   }
                   aria-label="Visit LinkedIn"
-                  title="Visit LinkedIn"
                 >
                   <Linkedin size={24} aria-hidden="true" />
                   <span
@@ -195,7 +193,6 @@ const Footer = React.memo(() => {
                     onClick={handleHeartClick}
                     className="group relative inline-flex cursor-pointer transition-transform hover:scale-125 p-0 bg-transparent border-none focus:outline-none focus-visible:ring-2 focus-visible:ring-fun-pink focus-visible:rounded-full"
                     aria-label="Give a like"
-                    title="Give a like"
                   >
                     <Heart
                       size={16}

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -338,7 +338,6 @@ const Navbar = React.memo(({ onOpenSettings }) => {
             onClick={onOpenSettings}
             className={`group relative hidden md:flex items-center justify-center p-2 rounded-full transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)] ${actionBtnCls}`}
             aria-label="Open settings"
-            title="Open settings"
             aria-haspopup="dialog"
           >
             <Settings size={18} aria-hidden="true" />

--- a/src/components/shared/ChatInterface.jsx
+++ b/src/components/shared/ChatInterface.jsx
@@ -657,7 +657,6 @@ const ChatInterface = ({ onClose }) => {
             onClick={onClose}
             className="group relative p-1 text-white hover:bg-white/20 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-accent rounded-sm"
             aria-label="Close chat (Escape)"
-            title="Close chat"
           >
             <X size={20} aria-hidden="true" />
             <span
@@ -757,7 +756,6 @@ const ChatInterface = ({ onClose }) => {
               )}
               style={isLiquid ? undefined : { boxShadow: '2px 2px 0 var(--color-border)' }}
               aria-label="Send message"
-              title="Send message"
             >
               <Send size={20} aria-hidden="true" />
               <span

--- a/src/components/shared/CommandPalette.jsx
+++ b/src/components/shared/CommandPalette.jsx
@@ -304,7 +304,6 @@ const CommandPalette = ({ isOpen, onClose, onOpenTerminal }) => {
                       : 'bg-secondary border-2 border-[color:var(--color-border)] hover:bg-fun-yellow rounded-nb'
                   )}
                   aria-label="Close command palette"
-                  title="Close command palette"
                 >
                   <X size={14} aria-hidden="true" />
                   <span

--- a/src/components/shared/Modal.jsx
+++ b/src/components/shared/Modal.jsx
@@ -151,7 +151,6 @@ const Modal = React.memo(({ isOpen, onClose, title, children }) => {
                 }
                 style={isLiquid ? undefined : { boxShadow: '2px 2px 0 var(--color-border)' }}
                 aria-label="Close modal"
-                title="Close modal"
               >
                 <X size={18} aria-hidden="true" />
                 <span

--- a/src/components/shared/RoastInterface.jsx
+++ b/src/components/shared/RoastInterface.jsx
@@ -139,7 +139,6 @@ const RoastInterface = ({ onClose, roastContent, onRoastComplete }) => {
           onClick={onClose}
           className="group relative p-1 text-white hover:bg-white/20 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-fun-pink rounded-sm"
           aria-label="Close roast"
-          title="Close roast"
         >
           <X size={20} aria-hidden="true" />
           <span
@@ -189,7 +188,6 @@ const RoastInterface = ({ onClose, roastContent, onRoastComplete }) => {
                   : 'text-muted hover:text-primary hover:bg-secondary'
               )}
               aria-label={isCopied ? 'Copied roast' : 'Copy roast to clipboard'}
-              title={isCopied ? 'Copied!' : 'Copy roast'}
             >
               {isCopied ? (
                 <Check size={16} aria-hidden="true" />


### PR DESCRIPTION
Removed native `title` attributes from icon buttons across the application (`RoastInterface.jsx`, `Modal.jsx`, `CommandPalette.jsx`, `ChatInterface.jsx`, `Navbar.jsx`, `Footer.jsx`). These buttons already had custom UI tooltips implemented (using hidden text spans that appear on hover/focus), and leaving the `title` attribute caused the browser's default native tooltip to render over top of the custom one, resulting in a confusing and unpolished "double-tooltip" effect.

Accessibility was strictly maintained by leaving all `aria-label` attributes fully intact for screen readers. Added a note regarding the UX improvement to `.jules/picasso.md`. Tested the application via Playwright screenshots to confirm frontend stability, and successfully ran the full local build/lint/test suite.

---
*PR created automatically by Jules for task [215948962784868063](https://jules.google.com/task/215948962784868063) started by @saint2706*