### PR TITLE
📚 Docs: Audit documentation and link View Transition guide

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,3 +116,8 @@
 - Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
 - Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
 - Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.
+
+## 2026-05-15
+
+- Audited documentation and verified no missing JSDoc comments or broken links.
+- Updated `README.md` to reference the new `docs/view-transition-navigation.md` file in the `docs/` directory under the Documentation section to keep the README in sync with the repository contents.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This repository is **pnpm-only**:
 
 ## 📚 Documentation
 
-Detailed documentation on project architecture, theming, and the games is available in the `.jules/` directory where the agents maintain historical logs and reports.
+Detailed documentation on project architecture, theming, and the games is available in the `.jules/` directory where the agents maintain historical logs and reports. Additional feature documentation, such as the [View Transition Navigation](docs/view-transition-navigation.md), can be found in the `docs/` directory.
 
 ## 📜 Scripts
 


### PR DESCRIPTION
I've acted as the Docs agent to audit and improve the project documentation:
- Ran a codebase-wide audit to look for missing JSDocs on exported functions/components and found none
- Ran an audit on all markdown files to find broken links and found no active issues
- Noticed the `docs/view-transition-navigation.md` file existed but wasn't referenced in `README.md`
- Linked `docs/view-transition-navigation.md` in the "Documentation" section of `README.md`
- Added an entry for my task to `.jules/docs-progress.md` logging the day's actions
- Ran the full suite of verification steps, ensuring all tests passed and no regressions were introduced

---
*PR created automatically by Jules for task [17800335851336828135](https://jules.google.com/task/17800335851336828135) started by @saint2706*