### PR TITLE
🎨 Picasso: [UX improvement] Remove redundant title attributes

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -6,3 +6,8 @@
 > > Added `aria-hidden="true"` to icon components if the parent button already has an `aria-label` or visible text to improve screen-reader accessibility and prevent redundant reading.
 > > Added title attributes to icon buttons for better tooltip UX and accessibility
 > > Removed redundant `title` attributes on elements that already implement custom UI tooltips (via inner span with hover states) to avoid the double-tooltip effect.
+
+## Avoid Double Tooltips / Redundant Titles
+
+- Found cases where components were using both `aria-label` (for screen readers) and `title` (for native tooltips), while also having visible text content (e.g. `Demo` and `Code` buttons in `Projects.jsx`).
+- **Learning**: Avoid adding a native HTML `title` attribute to elements that already possess clear, visible text labels (or custom UI tooltips), as the native tooltip is redundant, provides no additional value, and can cause a double-tooltip effect. `title` attributes should generally be reserved for icon-only interactive elements without custom tooltips.

--- a/src/components/pages/Projects.jsx
+++ b/src/components/pages/Projects.jsx
@@ -141,7 +141,6 @@ const ProjectCard = React.memo(
                 size="sm"
                 className={isLiquid ? undefined : 'hover:-translate-y-0.5'}
                 aria-label={`Live Demo for ${project.title} (opens in new tab)`}
-                title={`View live demo for ${project.title}`}
               >
                 <ExternalLink size={14} aria-hidden="true" /> Demo
               </ThemedButton>
@@ -157,7 +156,6 @@ const ProjectCard = React.memo(
                 size="sm"
                 className={isLiquid ? undefined : 'hover:-translate-y-0.5'}
                 aria-label={`View source code for ${project.title} on GitHub (opens in new tab)`}
-                title={`View source code for ${project.title} on GitHub`}
               >
                 <Github size={14} aria-hidden="true" /> Code
               </ThemedButton>


### PR DESCRIPTION
Removed redundant `title` attributes from `Demo` and `Code` buttons in `src/components/pages/Projects.jsx`. These buttons already had visible text labels and `aria-label`s, so the native tooltip created an unnecessary double-tooltip effect. Recorded learning in `.jules/picasso.md`.

---
*PR created automatically by Jules for task [15807965394864038701](https://jules.google.com/task/15807965394864038701) started by @saint2706*