### PR TITLE
🎨 Picasso: Removed redundant title attributes from icon buttons with visible text

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -6,3 +6,7 @@
 > > Added `aria-hidden="true"` to icon components if the parent button already has an `aria-label` or visible text to improve screen-reader accessibility and prevent redundant reading.
 > > Added title attributes to icon buttons for better tooltip UX and accessibility
 > > Removed redundant `title` attributes on elements that already implement custom UI tooltips (via inner span with hover states) to avoid the double-tooltip effect.
+
+## Picasso UX Improvements
+
+- Removed redundant native `title` attributes from the demo and code buttons in `src/components/pages/Projects.jsx`.

--- a/src/components/pages/Projects.jsx
+++ b/src/components/pages/Projects.jsx
@@ -141,7 +141,6 @@ const ProjectCard = React.memo(
                 size="sm"
                 className={isLiquid ? undefined : 'hover:-translate-y-0.5'}
                 aria-label={`Live Demo for ${project.title} (opens in new tab)`}
-                title={`View live demo for ${project.title}`}
               >
                 <ExternalLink size={14} aria-hidden="true" /> Demo
               </ThemedButton>
@@ -157,7 +156,6 @@ const ProjectCard = React.memo(
                 size="sm"
                 className={isLiquid ? undefined : 'hover:-translate-y-0.5'}
                 aria-label={`View source code for ${project.title} on GitHub (opens in new tab)`}
-                title={`View source code for ${project.title} on GitHub`}
               >
                 <Github size={14} aria-hidden="true" /> Code
               </ThemedButton>


### PR DESCRIPTION
Removed redundant native `title` attributes from the demo and code buttons in `src/components/pages/Projects.jsx` as they already possess clear, visible text labels ("Demo" and "Code"). This improves accessibility and avoids a double-tooltip effect.

---
*PR created automatically by Jules for task [16765219954964678805](https://jules.google.com/task/16765219954964678805) started by @saint2706*