### PR TITLE
🧘 Buddha: Removed redundant title attributes

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -338,3 +338,16 @@ Audited the codebase for Core Web Vitals (LCP, CLS, INP), structured data (JSON-
 - **[SEO/SEC]** `dangerouslySetInnerHTML` is correctly sanitized using `safeJSONStringify` in `SEOHead.jsx`.
 - **[PERF/SEO]** Checked `src/components/pages/Projects.jsx`. The project images are loaded using `img` tags. The first 3 project images (LCP candidates) have `loading="eager"` and `fetchPriority="high"`, whereas the rest have `loading="lazy"`. This correctly optimizes LCP while lazy loading the rest. The Hero section relies on text and CSS for rendering.
 - No further optimizations were necessary for these checks as everything aligns with Buddha SEO/GEO practices.
+
+## Date: 2026-05-04
+
+**Agent**: Jules (Buddha Persona)
+
+### Summary
+
+Removed redundant `title` attributes from buttons that already possess clear, visible text labels.
+
+### Changes
+
+1. **[SEO][GEO] Removed Redundant Tooltips:**
+   - Removed `title` attributes from interactive elements in `Projects.jsx` to prevent the undesirable 'double tooltip' effect and avoid redundant metadata since custom UI tooltips or clear textual labels are already implemented.

--- a/src/components/pages/Projects.jsx
+++ b/src/components/pages/Projects.jsx
@@ -141,7 +141,6 @@ const ProjectCard = React.memo(
                 size="sm"
                 className={isLiquid ? undefined : 'hover:-translate-y-0.5'}
                 aria-label={`Live Demo for ${project.title} (opens in new tab)`}
-                title={`View live demo for ${project.title}`}
               >
                 <ExternalLink size={14} aria-hidden="true" /> Demo
               </ThemedButton>
@@ -157,7 +156,6 @@ const ProjectCard = React.memo(
                 size="sm"
                 className={isLiquid ? undefined : 'hover:-translate-y-0.5'}
                 aria-label={`View source code for ${project.title} on GitHub (opens in new tab)`}
-                title={`View source code for ${project.title} on GitHub`}
               >
                 <Github size={14} aria-hidden="true" /> Code
               </ThemedButton>


### PR DESCRIPTION
Removed `title` attributes from the "Live Demo" and "Source Code" buttons in `src/components/pages/Projects.jsx` as they already possess clear, visible text labels ("Demo" and "Code") and robust `aria-label` tags. This prevents the undesirable 'double tooltip' effect and reduces redundant HTML metadata without compromising accessibility. All relevant build, formatting, linting, and test scripts passed successfully. Progress was recorded in `.jules/buddha-scroll.md`.

---
*PR created automatically by Jules for task [2122867784864595536](https://jules.google.com/task/2122867784864595536) started by @saint2706*