### PR TITLE
🎨 Picasso: Remove redundant tooltips from Project buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -6,3 +6,5 @@
 > > Added `aria-hidden="true"` to icon components if the parent button already has an `aria-label` or visible text to improve screen-reader accessibility and prevent redundant reading.
 > > Added title attributes to icon buttons for better tooltip UX and accessibility
 > > Removed redundant `title` attributes on elements that already implement custom UI tooltips (via inner span with hover states) to avoid the double-tooltip effect.
+
+- Removed redundant `title` attributes on buttons that already had text content and `aria-label` attributes, improving accessibility and avoiding tooltip redundancy.

--- a/src/components/pages/Projects.jsx
+++ b/src/components/pages/Projects.jsx
@@ -141,7 +141,6 @@ const ProjectCard = React.memo(
                 size="sm"
                 className={isLiquid ? undefined : 'hover:-translate-y-0.5'}
                 aria-label={`Live Demo for ${project.title} (opens in new tab)`}
-                title={`View live demo for ${project.title}`}
               >
                 <ExternalLink size={14} aria-hidden="true" /> Demo
               </ThemedButton>
@@ -157,7 +156,6 @@ const ProjectCard = React.memo(
                 size="sm"
                 className={isLiquid ? undefined : 'hover:-translate-y-0.5'}
                 aria-label={`View source code for ${project.title} on GitHub (opens in new tab)`}
-                title={`View source code for ${project.title} on GitHub`}
               >
                 <Github size={14} aria-hidden="true" /> Code
               </ThemedButton>


### PR DESCRIPTION
🎨 Picasso: Removed redundant `title` attributes from buttons in `src/components/pages/Projects.jsx`. The buttons already have visible text labels ("Demo", "Code") and comprehensive `aria-label` attributes. Removing the native `title` avoids a redundant "double tooltip" effect and improves interaction consistency. Also updated `.jules/picasso.md` with findings. Verified everything builds, formats correctly, and all tests pass perfectly.

---
*PR created automatically by Jules for task [16261266852112027092](https://jules.google.com/task/16261266852112027092) started by @saint2706*