### PR TITLE
📚 Docs: Audit JSDocs and markdown links

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,3 +116,10 @@
 - Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
 - Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
 - Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.
+
+## 2026-05-06
+
+- Audited codebase documentation for missing JSDoc/TSDoc comments on exported functions.
+- Verified that all exported functions and constants in the `src/` directory are already properly documented.
+- Verified no broken local markdown links in `docs/` and `README.md`.
+- Verified changes with standard local suite (`pnpm run build && pnpm run format:check && pnpm run lint && pnpm run test:run`) and cleaned up auto-generated `sitemap.xml` modifications to keep commits focused.


### PR DESCRIPTION
Audited the codebase documentation for missing JSDoc/TSDoc comments and broken local markdown links. Found that all exported functions and constants are already properly documented, and there are no broken local markdown links. Logged the findings in `.jules/docs-progress.md`.

---
*PR created automatically by Jules for task [3099260048710289904](https://jules.google.com/task/3099260048710289904) started by @saint2706*