### PR TITLE
🧘 Buddha: [SEO] Fix conflicting canonical URLs

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -338,3 +338,17 @@ Audited the codebase for Core Web Vitals (LCP, CLS, INP), structured data (JSON-
 - **[SEO/SEC]** `dangerouslySetInnerHTML` is correctly sanitized using `safeJSONStringify` in `SEOHead.jsx`.
 - **[PERF/SEO]** Checked `src/components/pages/Projects.jsx`. The project images are loaded using `img` tags. The first 3 project images (LCP candidates) have `loading="eager"` and `fetchPriority="high"`, whereas the rest have `loading="lazy"`. This correctly optimizes LCP while lazy loading the rest. The Hero section relies on text and CSS for rendering.
 - No further optimizations were necessary for these checks as everything aligns with Buddha SEO/GEO practices.
+
+## Date: 2026-05-18
+
+**Agent**: Jules (Buddha Persona)
+
+### Summary
+
+Fixed conflicting canonical URLs issue in Lighthouse SEO audit.
+
+### Changes
+
+1.  **[SEO] Fixed conflicting canonical URLs**:
+    - Removed hardcoded `<link rel="canonical" href="https://saint2706.github.io/" />` from `index.html`.
+    - Relying exclusively on `src/components/shared/SEOHead.jsx` to dynamically inject the correct canonical URL per route, fixing the Lighthouse "Document does not have a valid `rel=canonical`" warning.

--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
       name="robots"
       content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
     />
-    <link rel="canonical" href="https://saint2706.github.io/" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />


### PR DESCRIPTION
This PR fixes a Lighthouse SEO audit issue where sub-pages (like `/playground`) had multiple conflicting canonical URLs.

The hardcoded `<link rel="canonical">` was removed from `index.html`. The application now relies solely on the `SEOHead` React component to dynamically inject the correct canonical URL based on the current route.

---
*PR created automatically by Jules for task [6088376609201398983](https://jules.google.com/task/6088376609201398983) started by @saint2706*