### PR TITLE
🛡️ Sentinel: Fixed moderate XSS vulnerability in ip-address

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,4 @@ Resolved High severity vulnerability in a deep transitive dependency of Lighthou
 - **[SEC-DEP] PostCSS XSS via Unescaped <style> (GHSA-qx2v-qp2m-jg93)**:
   - Discovered a Moderate severity vulnerability in `postcss@8.5.8` via `pnpm audit`.
   - Upgraded `postcss` to `8.5.10` using `pnpm install postcss@8.5.10`.
+- Mitigated a moderate XSS vulnerability in the ip-address dependency by enforcing version >=10.1.1 via pnpm.overrides in package.json.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
       "picomatch@^2": "^2.3.2",
       "picomatch@^4": "^4.0.4",
       "yaml": "^2.8.3",
-      "lodash-es": ">=4.18.0"
+      "lodash-es": ">=4.18.0",
+      "ip-address": ">=10.1.1"
     },
     "onlyBuiltDependencies": [
       "esbuild"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   picomatch@^4: ^4.0.4
   yaml: ^2.8.3
   lodash-es: '>=4.18.0'
+  ip-address: '>=10.1.1'
 
 importers:
 
@@ -1965,8 +1966,8 @@ packages:
   intl-messageformat@10.7.18:
     resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   is-alphabetical@2.0.1:
@@ -5358,7 +5359,7 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 2.11.4
       tslib: 2.8.1
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -6520,7 +6521,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}


### PR DESCRIPTION
- Added `"ip-address": ">=10.1.1"` to `pnpm.overrides` in `package.json` to enforce the patched version of the transitive dependency used by `lighthouse`.
- Ran `pnpm install` to update `pnpm-lock.yaml`.
- Verified mitigation with `pnpm audit`.
- Recorded learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1646991798564405391](https://jules.google.com/task/1646991798564405391) started by @saint2706*