### PR TITLE
🎨 Picasso: [UX improvement] Add ARIA live regions to empty states

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -6,3 +6,6 @@
 > > Added `aria-hidden="true"` to icon components if the parent button already has an `aria-label` or visible text to improve screen-reader accessibility and prevent redundant reading.
 > > Added title attributes to icon buttons for better tooltip UX and accessibility
 > > Removed redundant `title` attributes on elements that already implement custom UI tooltips (via inner span with hover states) to avoid the double-tooltip effect.
+
+### UX/Accessibility Enhancements - Empty States
+- Improved accessibility in \`Playground.jsx\` and \`CommandPalette.jsx\` by adding \`role="status"\` and \`aria-live="polite"\` to the empty state containers. This ensures that screen readers proactively announce when searches or filtering yield no results, preventing confusion for visually impaired users.

--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -8,4 +8,5 @@
 > > Removed redundant `title` attributes on elements that already implement custom UI tooltips (via inner span with hover states) to avoid the double-tooltip effect.
 
 ### UX/Accessibility Enhancements - Empty States
+
 - Improved accessibility in \`Playground.jsx\` and \`CommandPalette.jsx\` by adding \`role="status"\` and \`aria-live="polite"\` to the empty state containers. This ensures that screen readers proactively announce when searches or filtering yield no results, preventing confusion for visually impaired users.

--- a/src/components/pages/Playground.jsx
+++ b/src/components/pages/Playground.jsx
@@ -287,6 +287,8 @@ const Playground = React.memo(() => {
                 animate="animate"
                 exit="exit"
                 className="col-span-full text-center py-12"
+                role="status"
+                aria-live="polite"
               >
                 <Code2 className="mx-auto h-12 w-12 text-gray-400" aria-hidden="true" />
                 <h2 className="mt-4 text-lg font-heading font-bold text-[color:var(--text-primary)]">

--- a/src/components/shared/CommandPalette.jsx
+++ b/src/components/shared/CommandPalette.jsx
@@ -324,7 +324,11 @@ const CommandPalette = ({ isOpen, onClose, onOpenTerminal }) => {
                 aria-label="Commands"
               >
                 {filteredCommands.length === 0 ? (
-                  <div className="px-4 py-8 text-center text-secondary font-sans">
+                  <div
+                    className="px-4 py-8 text-center text-secondary font-sans"
+                    role="status"
+                    aria-live="polite"
+                  >
                     No commands found for &ldquo;{query}&rdquo;
                   </div>
                 ) : (


### PR DESCRIPTION
Added `role="status"` and `aria-live="polite"` attributes to the empty state containers in `Playground.jsx` and `CommandPalette.jsx`. This ensures screen readers proactively announce when searches or filtering yield no results, improving accessibility and reducing confusion for visually impaired users.

---
*PR created automatically by Jules for task [6310037942011612447](https://jules.google.com/task/6310037942011612447) started by @saint2706*