### PR TITLE
📚 Docs: Add missing JSDoc @returns annotations to React components

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,3 +116,8 @@
 - Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
 - Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
 - Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.
+
+## 2026-05-15
+
+- Audited codebase documentation for missing JSDoc/TSDoc comments on exported React components.
+- Added `@returns {JSX.Element}` annotations to the JSDoc blocks of `Hero` (`src/components/home/Hero.jsx`), `SettingsModal` (`src/components/shared/SettingsModal.jsx`), `SEOHead` (`src/components/shared/SEOHead.jsx`), `MarqueeTicker` (`src/components/shared/MarqueeTicker.jsx`), and `ZigzagDivider` (`src/components/shared/ZigzagDivider.jsx`) components to improve documentation completeness.

--- a/src/components/home/Hero.jsx
+++ b/src/components/home/Hero.jsx
@@ -53,6 +53,7 @@ const snippetStickerStyle = { '--sticker-rotate': '-1deg' };
 /**
  * Hero section component for homepage
  * @type {React.NamedExoticComponent}
+ * @returns {JSX.Element} The Hero section component.
  */
 const Hero = React.memo(() => {
   const shouldReduceMotion = useReducedMotion();

--- a/src/components/shared/MarqueeTicker.jsx
+++ b/src/components/shared/MarqueeTicker.jsx
@@ -36,6 +36,7 @@ const DEFAULT_ITEMS = [
  * @param {'neub'|'liquid'} [props.variant] - Visual style variant
  * @param {boolean} [props.useBlurBand] - Adds a glassy blur backdrop for liquid variant
  * @param {string} [props.className] - Additional wrapper classes
+ * @returns {JSX.Element} The MarqueeTicker component.
  */
 const MarqueeTicker = ({
   items = DEFAULT_ITEMS,

--- a/src/components/shared/SEOHead.jsx
+++ b/src/components/shared/SEOHead.jsx
@@ -40,6 +40,7 @@ import {
  * @param {Array}   [props.schemas]    — Array of JSON-LD schema objects to inject
  * @param {string}  [props.author]     — Override author name
  * @param {React.ReactNode} [props.children] — Extra <Helmet> children
+ * @returns {JSX.Element} The SEOHead component.
  */
 const SEOHead = ({
   title,

--- a/src/components/shared/SettingsModal.jsx
+++ b/src/components/shared/SettingsModal.jsx
@@ -108,6 +108,7 @@ const ThemeCard = ({ option, isActive, onClick }) => {
  * @param {boolean} props.cursorEnabled - Current cursor state.
  * @param {boolean} props.cursorToggleDisabled - Whether cursor toggle is locked by a11y prefs.
  * @param {Function} props.onToggleCursor - Cursor toggle handler.
+ * @returns {JSX.Element|null} The SettingsModal component or null if closed.
  */
 const SettingsModal = ({
   isOpen,

--- a/src/components/shared/ZigzagDivider.jsx
+++ b/src/components/shared/ZigzagDivider.jsx
@@ -13,6 +13,7 @@ import React from 'react';
  * @param {string} [props.fillColor] - Fill color for the zigzag (default: black)
  * @param {number} [props.height] - Height in pixels (default: 20)
  * @param {string} [props.className] - Additional wrapper classes
+ * @returns {JSX.Element|null} The ZigzagDivider component.
  */
 const ZigzagDivider = ({
   variant = 'zigzag',


### PR DESCRIPTION
The "Docs" 📚 agent has performed an audit of the codebase to identify exported React components that were missing `@returns` annotations in their JSDoc blocks.

**Changes made:**
- `src/components/home/Hero.jsx`: Added `@returns {JSX.Element}` to the `Hero` component.
- `src/components/shared/SettingsModal.jsx`: Added `@returns {JSX.Element|null}` to the `SettingsModal` component.
- `src/components/shared/SEOHead.jsx`: Added `@returns {JSX.Element}` to the `SEOHead` component.
- `src/components/shared/MarqueeTicker.jsx`: Added `@returns {JSX.Element}` to the `MarqueeTicker` component.
- `src/components/shared/ZigzagDivider.jsx`: Added `@returns {JSX.Element|null}` to the `ZigzagDivider` component.
- Updated `.jules/docs-progress.md` with an entry documenting these additions.

All updates follow standard documentation guidelines to ensure code quality and readability. The full verification suite (build, format check, lint, and tests) passes cleanly, and auto-generated build files (`sitemap.xml`, `llms.txt`) have been successfully restored.

---
*PR created automatically by Jules for task [8916139397018847531](https://jules.google.com/task/8916139397018847531) started by @saint2706*