### PR TITLE
📚 Docs: Add missing @returns tags and audit links

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,3 +116,8 @@
 - Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
 - Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
 - Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.
+## 2026-05-17
+
+- Audited documentation for broken links using `markdown-link-check` and found 0 broken links.
+- Added missing JSDoc `@returns` tags to `src/components/home/Hero.jsx`, `src/components/shared/SettingsModal.jsx`, `src/components/shared/SEOHead.jsx`, `src/components/shared/MarqueeTicker.jsx`, and `src/components/shared/ZigzagDivider.jsx`.
+- Verified changes with standard local suite (`pnpm run audit:baseline`).

--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,6 +116,7 @@
 - Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
 - Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
 - Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.
+
 ## 2026-05-17
 
 - Audited documentation for broken links using `markdown-link-check` and found 0 broken links.

--- a/src/components/home/Hero.jsx
+++ b/src/components/home/Hero.jsx
@@ -52,6 +52,7 @@ const snippetStickerStyle = { '--sticker-rotate': '-1deg' };
 
 /**
  * Hero section component for homepage
+ * @returns {JSX.Element} The rendered Hero component
  * @type {React.NamedExoticComponent}
  */
 const Hero = React.memo(() => {
@@ -405,6 +406,7 @@ const Hero = React.memo(() => {
 Hero.displayName = 'Hero';
 
 /**
+ * @returns {JSX.Element} The rendered Hero component
  * @type {React.NamedExoticComponent}
  */
 export default Hero;

--- a/src/components/shared/MarqueeTicker.jsx
+++ b/src/components/shared/MarqueeTicker.jsx
@@ -36,6 +36,7 @@ const DEFAULT_ITEMS = [
  * @param {'neub'|'liquid'} [props.variant] - Visual style variant
  * @param {boolean} [props.useBlurBand] - Adds a glassy blur backdrop for liquid variant
  * @param {string} [props.className] - Additional wrapper classes
+ * @returns {JSX.Element} The rendered MarqueeTicker component
  */
 const MarqueeTicker = ({
   items = DEFAULT_ITEMS,

--- a/src/components/shared/SEOHead.jsx
+++ b/src/components/shared/SEOHead.jsx
@@ -40,6 +40,7 @@ import {
  * @param {Array}   [props.schemas]    — Array of JSON-LD schema objects to inject
  * @param {string}  [props.author]     — Override author name
  * @param {React.ReactNode} [props.children] — Extra <Helmet> children
+ * @returns {JSX.Element} The rendered SEOHead component
  */
 const SEOHead = ({
   title,

--- a/src/components/shared/SettingsModal.jsx
+++ b/src/components/shared/SettingsModal.jsx
@@ -108,6 +108,7 @@ const ThemeCard = ({ option, isActive, onClick }) => {
  * @param {boolean} props.cursorEnabled - Current cursor state.
  * @param {boolean} props.cursorToggleDisabled - Whether cursor toggle is locked by a11y prefs.
  * @param {Function} props.onToggleCursor - Cursor toggle handler.
+ * @returns {JSX.Element|null} The rendered SettingsModal component, or null if not open.
  */
 const SettingsModal = ({
   isOpen,

--- a/src/components/shared/ZigzagDivider.jsx
+++ b/src/components/shared/ZigzagDivider.jsx
@@ -13,6 +13,7 @@ import React from 'react';
  * @param {string} [props.fillColor] - Fill color for the zigzag (default: black)
  * @param {number} [props.height] - Height in pixels (default: 20)
  * @param {string} [props.className] - Additional wrapper classes
+ * @returns {JSX.Element|null} The rendered ZigzagDivider component, or null if variant is "none"
  */
 const ZigzagDivider = ({
   variant = 'zigzag',


### PR DESCRIPTION
Audited the documentation and source files for broken links using `markdown-link-check` and found none. Added missing JSDoc `@returns` tags to multiple React components (`Hero`, `SettingsModal`, `SEOHead`, `MarqueeTicker`, and `ZigzagDivider`) to improve documentation accuracy and completeness per the Docs agent persona. Updated `.jules/docs-progress.md` with the daily process summary.

---
*PR created automatically by Jules for task [9519634904536602776](https://jules.google.com/task/9519634904536602776) started by @saint2706*