### PR TITLE
🛡️ Sentinel: Fix brace-expansion DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -45,3 +45,4 @@ Resolved High severity vulnerability in a deep transitive dependency of Lighthou
   - Discovered a Moderate severity vulnerability in `postcss@8.5.8` via `pnpm audit`.
   - Upgraded `postcss` to `8.5.10` using `pnpm install postcss@8.5.10`.
 - Mitigated a moderate XSS vulnerability in the ip-address dependency by enforcing version >=10.1.1 via pnpm.overrides in package.json.
+- **[SEC]** Fixed `brace-expansion` DoS vulnerability by forcing its version to `>=5.0.6` via `pnpm.overrides` in `package.json`.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
       "picomatch@^4": "^4.0.4",
       "yaml": "^2.8.3",
       "lodash-es": ">=4.18.0",
-      "ip-address": ">=10.1.1"
+      "ip-address": ">=10.1.1",
+      "brace-expansion": ">=5.0.6"
     },
     "onlyBuiltDependencies": [
       "esbuild"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   yaml: ^2.8.3
   lodash-es: '>=4.18.0'
   ip-address: '>=10.1.1'
+  brace-expansion: '>=5.0.6'
 
 importers:
 
@@ -1311,8 +1312,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -3009,6 +3010,9 @@ packages:
   third-party-web@0.29.0:
     resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
 
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3978,7 +3982,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.61':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -4554,7 +4558,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5996,7 +6000,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   mitt@3.0.1: {}
 
@@ -6707,6 +6711,8 @@ snapshots:
       - react-native-b4a
 
   third-party-web@0.29.0: {}
+
+  third-party-web@0.29.2: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
This pull request addresses a Moderate severity Denial of Service (DoS) vulnerability in the `brace-expansion` dependency. 

**Vulnerability Context:**
Versions of `brace-expansion` prior to 5.0.6 are vulnerable to a DoS attack where a carefully crafted payload with extremely large numeric ranges can cause excessive memory consumption, bypassing the documented `max` limit protections.

**Changes:**
- Added a `pnpm.overrides` rule in `package.json` to strictly enforce `brace-expansion` to version `>=5.0.6`.
- Refreshed the lockfile to ensure the patched version is utilized across the dependency tree.
- Appended audit findings and mitigation details to `.jules/sentinel.md` to maintain the project's security tracking.

All tests and lint checks pass cleanly.

---
*PR created automatically by Jules for task [266893313613780069](https://jules.google.com/task/266893313613780069) started by @saint2706*