### PR TITLE
📚 Docs: Fix missing JSDoc annotations and update progress log

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,3 +116,8 @@
 - Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
 - Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
 - Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.
+
+## 2026-05-18
+
+- Audited codebase documentation and verified all `pnpm run lint`, `pnpm run format:check`, and `npx markdown-link-check` passed successfully. No new broken links, unformatted code, or missing JSDocs were found.
+- Fixed a missing `@returns` JSDoc annotation in the `SettingsModal` component (`src/components/shared/SettingsModal.jsx`).

--- a/src/components/shared/SettingsModal.jsx
+++ b/src/components/shared/SettingsModal.jsx
@@ -108,6 +108,7 @@ const ThemeCard = ({ option, isActive, onClick }) => {
  * @param {boolean} props.cursorEnabled - Current cursor state.
  * @param {boolean} props.cursorToggleDisabled - Whether cursor toggle is locked by a11y prefs.
  * @param {Function} props.onToggleCursor - Cursor toggle handler.
+ * @returns {React.ReactElement|null} The SettingsModal component or null if not open.
  */
 const SettingsModal = ({
   isOpen,


### PR DESCRIPTION
As the "Docs" agent, I conducted an audit of the documentation, ensuring accuracy and completeness. 

Changes include:
- Fixed a missing `@returns` JSDoc annotation in the `SettingsModal` component (`src/components/shared/SettingsModal.jsx`) which improves type safety and API reference readability.
- Validated markdown files using `markdown-link-check` and successfully executed `pnpm run format:check` and `pnpm run lint` across the workspace.
- Logged the task completion and audit verification results in `.jules/docs-progress.md` as per the expected process.
- All baseline tests pass with `pnpm run audit:baseline`.

---
*PR created automatically by Jules for task [17498364545260016589](https://jules.google.com/task/17498364545260016589) started by @saint2706*