### PR TITLE
📚 Docs: Add missing @returns annotations to components

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,3 +116,8 @@
 - Identified false positive broken link `https://play.tailwindcss.com` in `.agents/skills/tailwind-css-patterns/SKILL.md` (returned Status 0 due to network configuration/rate limiting).
 - Manually verified the URL is active and returning HTTP 200. No functional changes were required for this link.
 - Verified workspace passes `pnpm run build`, `pnpm run lint`, and `pnpm run format:check`.
+
+## 2026-04-30
+
+- Audited documentation for missing JSDoc return types.
+- Added `@returns {JSX.Element}` and `@returns {JSX.Element|null}` annotations to `Hero`, `SettingsModal`, `SEOHead`, `MarqueeTicker`, and `ZigzagDivider` components.

--- a/src/components/home/Hero.jsx
+++ b/src/components/home/Hero.jsx
@@ -25,6 +25,8 @@ import HeroBackground from './HeroBackground';
 /**
  * Hero section component for homepage
  * Performance optimization: Wrapped in React.memo to prevent unnecessary re-renders
+ *
+ * @returns {JSX.Element}
  */
 // ⚡ Bolt: Extracted static animation objects to prevent re-renders
 const badgeInitial = { opacity: 0, scale: 1.15, rotate: 3 };

--- a/src/components/shared/MarqueeTicker.jsx
+++ b/src/components/shared/MarqueeTicker.jsx
@@ -36,6 +36,7 @@ const DEFAULT_ITEMS = [
  * @param {'neub'|'liquid'} [props.variant] - Visual style variant
  * @param {boolean} [props.useBlurBand] - Adds a glassy blur backdrop for liquid variant
  * @param {string} [props.className] - Additional wrapper classes
+ * @returns {JSX.Element}
  */
 const MarqueeTicker = ({
   items = DEFAULT_ITEMS,

--- a/src/components/shared/SEOHead.jsx
+++ b/src/components/shared/SEOHead.jsx
@@ -40,6 +40,7 @@ import {
  * @param {Array}   [props.schemas]    — Array of JSON-LD schema objects to inject
  * @param {string}  [props.author]     — Override author name
  * @param {React.ReactNode} [props.children] — Extra <Helmet> children
+ * @returns {JSX.Element}
  */
 const SEOHead = ({
   title,

--- a/src/components/shared/SettingsModal.jsx
+++ b/src/components/shared/SettingsModal.jsx
@@ -108,6 +108,7 @@ const ThemeCard = ({ option, isActive, onClick }) => {
  * @param {boolean} props.cursorEnabled - Current cursor state.
  * @param {boolean} props.cursorToggleDisabled - Whether cursor toggle is locked by a11y prefs.
  * @param {Function} props.onToggleCursor - Cursor toggle handler.
+ * @returns {JSX.Element}
  */
 const SettingsModal = ({
   isOpen,

--- a/src/components/shared/ZigzagDivider.jsx
+++ b/src/components/shared/ZigzagDivider.jsx
@@ -13,6 +13,7 @@ import React from 'react';
  * @param {string} [props.fillColor] - Fill color for the zigzag (default: black)
  * @param {number} [props.height] - Height in pixels (default: 20)
  * @param {string} [props.className] - Additional wrapper classes
+ * @returns {JSX.Element|null}
  */
 const ZigzagDivider = ({
   variant = 'zigzag',


### PR DESCRIPTION
Added missing `@returns` JSDoc annotations to several exported React components. This aligns with the "Docs" agent directive to ensure API and component documentation completeness.

- `src/components/home/Hero.jsx`: Added `@returns {JSX.Element}`
- `src/components/shared/SettingsModal.jsx`: Added `@returns {JSX.Element}`
- `src/components/shared/SEOHead.jsx`: Added `@returns {JSX.Element}`
- `src/components/shared/MarqueeTicker.jsx`: Added `@returns {JSX.Element}`
- `src/components/shared/ZigzagDivider.jsx`: Added `@returns {JSX.Element|null}`

All code formatting, linting, and tests successfully pass without regressions. The progress has been securely documented in `.jules/docs-progress.md`.

---
*PR created automatically by Jules for task [6032626734212041871](https://jules.google.com/task/6032626734212041871) started by @saint2706*