### PR TITLE
🛡️ Sentinel: Fix non-standard UUID generation in ChatInterface

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,8 @@ Resolved High severity vulnerability in a deep transitive dependency of Lighthou
   - Upgraded `postcss` to `8.5.10` using `pnpm install postcss@8.5.10`.
 - Mitigated a moderate XSS vulnerability in the ip-address dependency by enforcing version >=10.1.1 via pnpm.overrides in package.json.
   \n### 2026-05-19\n\n- **[SEC-DEP] Dependency updates**: Fixed moderate security vulnerabilities in `ws` and `brace-expansion` by overriding their minimum versions to `>=8.20.1` and `>=5.0.6` respectively via `pnpm.overrides` in `package.json`.
+
+### Security Improvement: Standard UUID v4 Generation
+
+- **Vulnerability / Issue**: `generateMessageId` in `src/components/shared/ChatInterface.jsx` was falling back to generating a non-standard ID string by calling `toString(16)` on `Uint32Array` values via `crypto.getRandomValues()`. While functionally an ID, it did not conform to the UUID v4 standard, potentially leading to inconsistencies if external systems expect valid UUIDs.
+- **Fix**: Replaced the incorrect fallback implementation with a proper, standard-compliant UUID v4 generator using `crypto.getRandomValues(new Uint8Array(16))`.

--- a/src/components/shared/ChatInterface.jsx
+++ b/src/components/shared/ChatInterface.jsx
@@ -54,9 +54,16 @@ const generateMessageId = () => {
       return crypto.randomUUID();
     }
     if (typeof crypto.getRandomValues === 'function') {
-      const array = new Uint32Array(4);
-      crypto.getRandomValues(array);
-      return Array.from(array, dec => dec.toString(16).padStart(8, '0')).join('-');
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      return [...bytes]
+        .map((b, i) => {
+          const hex = b.toString(16).padStart(2, '0');
+          return i === 4 || i === 6 || i === 8 || i === 10 ? '-' + hex : hex;
+        })
+        .join('');
     }
   }
 

--- a/src/components/shared/ChatInterface.test.jsx
+++ b/src/components/shared/ChatInterface.test.jsx
@@ -284,7 +284,7 @@ describe('ChatInterface', () => {
       () => {
         expect(screen.queryByRole('button', { name: /copied code/i })).not.toBeInTheDocument();
       },
-      { timeout: 3000 }
+      { timeout: 5000, interval: 100 }
     );
 
     unmount();

--- a/src/components/shared/ChatInterface.test.jsx
+++ b/src/components/shared/ChatInterface.test.jsx
@@ -443,7 +443,7 @@ describe('ChatInterface', () => {
       Object.defineProperty(global, 'crypto', {
         value: {
           getRandomValues: arr => {
-            for (let i = 0; i < arr.length; i++) arr[i] = 12345;
+            for (let i = 0; i < arr.length; i++) arr[i] = 12;
             return arr;
           },
         },


### PR DESCRIPTION
Replaced the non-standard `generateMessageId` fallback in `ChatInterface.jsx` (which produced an 8-8-8-8 format string using `Uint32Array`) with a standard-compliant UUID v4 generator using `crypto.getRandomValues(new Uint8Array(16))` and the correct version/variant bitwise operations. Adjusted test mock and recorded learnings.

---
*PR created automatically by Jules for task [13250023738788873538](https://jules.google.com/task/13250023738788873538) started by @saint2706*