### PR TITLE
🛡️ Sentinel: Fix UUIDv4 standards compliance in ChatInterface fallback generator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,8 @@ Resolved High severity vulnerability in a deep transitive dependency of Lighthou
   - Upgraded `postcss` to `8.5.10` using `pnpm install postcss@8.5.10`.
 - Mitigated a moderate XSS vulnerability in the ip-address dependency by enforcing version >=10.1.1 via pnpm.overrides in package.json.
   \n### 2026-05-19\n\n- **[SEC-DEP] Dependency updates**: Fixed moderate security vulnerabilities in `ws` and `brace-expansion` by overriding their minimum versions to `>=8.20.1` and `>=5.0.6` respectively via `pnpm.overrides` in `package.json`.
+
+### Security Improvement: Standard UUIDv4 Generation
+
+- **Vulnerability**: The fallback UUID generator in `src/components/shared/ChatInterface.jsx` was using `crypto.getRandomValues(new Uint32Array(4))` and formatting it as a generic hex string, missing required version and variant bits for standard UUIDv4 compliance.
+- **Fix**: Updated `generateMessageId` to use `Uint8Array(16)`, setting standard UUIDv4 version (`4`) and variant (`8`, `9`, `A`, or `B`) bits before formatting it as an `8-4-4-4-12` hex string. Also updated the corresponding test in `ChatInterface.test.jsx`.

--- a/src/components/shared/ChatInterface.jsx
+++ b/src/components/shared/ChatInterface.jsx
@@ -54,9 +54,18 @@ const generateMessageId = () => {
       return crypto.randomUUID();
     }
     if (typeof crypto.getRandomValues === 'function') {
-      const array = new Uint32Array(4);
-      crypto.getRandomValues(array);
-      return Array.from(array, dec => dec.toString(16).padStart(8, '0')).join('-');
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40; // Set version to 4
+      bytes[8] = (bytes[8] & 0x3f) | 0x80; // Set variant to 8, 9, A, or B
+      const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0'));
+      return [
+        hex.slice(0, 4).join(''),
+        hex.slice(4, 6).join(''),
+        hex.slice(6, 8).join(''),
+        hex.slice(8, 10).join(''),
+        hex.slice(10, 16).join(''),
+      ].join('-');
     }
   }
 

--- a/src/components/shared/ChatInterface.test.jsx
+++ b/src/components/shared/ChatInterface.test.jsx
@@ -443,7 +443,7 @@ describe('ChatInterface', () => {
       Object.defineProperty(global, 'crypto', {
         value: {
           getRandomValues: arr => {
-            for (let i = 0; i < arr.length; i++) arr[i] = 12345;
+            for (let i = 0; i < arr.length; i++) arr[i] = 12;
             return arr;
           },
         },


### PR DESCRIPTION
Updated the fallback UUID generator in `src/components/shared/ChatInterface.jsx` to correctly implement the UUIDv4 standard by setting the required version and variant bits on a 16-byte cryptographically secure random array. Updated the corresponding test mock and documented the change.

---
*PR created automatically by Jules for task [10873494257768933619](https://jules.google.com/task/10873494257768933619) started by @saint2706*