### PR TITLE
📚 Docs: Add missing JSDocs to game subcomponents and default exports

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -121,3 +121,5 @@
 
 - Audited documentation for missing JSDoc return types.
 - Added `@returns {JSX.Element}` and `@returns {JSX.Element|null}` annotations to `Hero`, `SettingsModal`, `SEOHead`, `MarqueeTicker`, and `ZigzagDivider` components.
+- Added missing JSDoc comments to MemoryMatchCard, MinesweeperCell, and TicTacToeCell.
+- Added type annotations to default exports in games and shared components.

--- a/src/components/games/LightsOut.jsx
+++ b/src/components/games/LightsOut.jsx
@@ -404,4 +404,7 @@ const LightsOut = React.memo(() => {
 
 LightsOut.displayName = 'LightsOut';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default LightsOut;

--- a/src/components/games/MemoryMatch.jsx
+++ b/src/components/games/MemoryMatch.jsx
@@ -40,6 +40,19 @@ const shuffle = arr => {
 const createDeck = () =>
   shuffle([...ICONS, ...ICONS].map((icon, i) => ({ id: i, icon, matched: false })));
 
+/**
+ * Individual card component for the Memory Match game.
+ * Memoized to prevent re-renders of unaffected cards.
+ *
+ * @param {Object} props - The component props.
+ * @param {Object} props.card - The card data object containing id and icon.
+ * @param {boolean} props.isFlipped - Whether the card is currently flipped face up.
+ * @param {boolean} props.isMatched - Whether the card has been successfully matched.
+ * @param {Function} props.onClick - Handler for when the card is clicked.
+ * @param {boolean} props.isLiquid - Whether the current theme is liquid.
+ * @param {boolean} props.shouldReduceMotion - Whether the user prefers reduced motion.
+ * @returns {React.ReactElement} The MemoryMatchCard component.
+ */
 const MemoryMatchCard = React.memo(
   ({
     card,
@@ -417,4 +430,7 @@ const MemoryMatch = React.memo(() => {
 
 MemoryMatch.displayName = 'MemoryMatch';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default MemoryMatch;

--- a/src/components/games/Minesweeper.jsx
+++ b/src/components/games/Minesweeper.jsx
@@ -105,6 +105,21 @@ const ADJACENT_COLORS = [
   'text-gray-500',
 ];
 
+/**
+ * Individual cell component for the Minesweeper game.
+ * Memoized to prevent re-renders of unaffected cells.
+ *
+ * @param {Object} props - The component props.
+ * @param {number} props.r - The row index of the cell.
+ * @param {number} props.c - The column index of the cell.
+ * @param {Object} props.cell - The state object for the cell (isMine, isRevealed, isFlagged, neighborCount).
+ * @param {Function} props.onClick - Handler for when the cell is left-clicked (reveal).
+ * @param {Function} props.onRightClick - Handler for when the cell is right-clicked (flag).
+ * @param {boolean} props.isGameOver - Whether the game is currently over.
+ * @param {boolean} props.isLiquid - Whether the current theme is liquid.
+ * @param {boolean} props.shouldReduceMotion - Whether the user prefers reduced motion.
+ * @returns {React.ReactElement} The MinesweeperCell component.
+ */
 const MinesweeperCell = React.memo(
   ({
     r,
@@ -589,4 +604,7 @@ const Minesweeper = React.memo(() => {
 
 Minesweeper.displayName = 'Minesweeper';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default Minesweeper;

--- a/src/components/games/SimonSays.jsx
+++ b/src/components/games/SimonSays.jsx
@@ -370,4 +370,7 @@ const SimonSays = React.memo(() => {
 
 SimonSays.displayName = 'SimonSays';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default SimonSays;

--- a/src/components/games/SnakeGame.jsx
+++ b/src/components/games/SnakeGame.jsx
@@ -856,4 +856,7 @@ const SnakeGame = React.memo(() => {
 
 SnakeGame.displayName = 'SnakeGame';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default SnakeGame;

--- a/src/components/games/TicTacToe.jsx
+++ b/src/components/games/TicTacToe.jsx
@@ -156,6 +156,20 @@ const getCellLabel = (index, cell) => {
   return `Row ${row}, Column ${col}, ${state}`;
 };
 
+/**
+ * Individual cell component for the Tic Tac Toe game.
+ * Memoized to prevent re-renders of unaffected cells.
+ *
+ * @param {Object} props - The component props.
+ * @param {string|null} props.cell - The current value of the cell ('X', 'O', or null).
+ * @param {number} props.index - The index of the cell in the board array.
+ * @param {boolean} props.isWinningCell - Whether the cell is part of the winning combination.
+ * @param {boolean} props.disabled - Whether the cell is disabled from interaction.
+ * @param {Function} props.onClick - Handler for when the cell is clicked.
+ * @param {boolean} props.isLiquid - Whether the current theme is liquid.
+ * @param {boolean} props.shouldReduceMotion - Whether the user prefers reduced motion.
+ * @returns {React.ReactElement} The TicTacToeCell component.
+ */
 const TicTacToeCell = React.memo(
   ({
     cell,
@@ -620,4 +634,7 @@ const TicTacToe = React.memo(() => {
 
 TicTacToe.displayName = 'TicTacToe';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default TicTacToe;

--- a/src/components/games/WhackAMole.jsx
+++ b/src/components/games/WhackAMole.jsx
@@ -412,4 +412,7 @@ const WhackAMole = React.memo(() => {
 
 WhackAMole.displayName = 'WhackAMole';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default WhackAMole;

--- a/src/components/shared/ChatInterface.jsx
+++ b/src/components/shared/ChatInterface.jsx
@@ -772,4 +772,7 @@ const ChatInterface = ({ onClose }) => {
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default ChatInterface;

--- a/src/components/shared/Chatbot.jsx
+++ b/src/components/shared/Chatbot.jsx
@@ -347,4 +347,7 @@ const Chatbot = React.memo(() => {
 
 Chatbot.displayName = 'Chatbot';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default Chatbot;

--- a/src/components/shared/CommandPalette.jsx
+++ b/src/components/shared/CommandPalette.jsx
@@ -424,4 +424,7 @@ const CommandItem = React.memo(
 );
 CommandItem.displayName = 'CommandItem';
 
+/**
+ * @type {React.FC}
+ */
 export default CommandPalette;

--- a/src/components/shared/CustomCursor.jsx
+++ b/src/components/shared/CustomCursor.jsx
@@ -308,4 +308,7 @@ const CustomCursor = ({ enabled }) => {
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default CustomCursor;

--- a/src/components/shared/MarqueeTicker.jsx
+++ b/src/components/shared/MarqueeTicker.jsx
@@ -79,4 +79,7 @@ const MarqueeTicker = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default MarqueeTicker;

--- a/src/components/shared/Modal.jsx
+++ b/src/components/shared/Modal.jsx
@@ -173,4 +173,7 @@ const Modal = React.memo(({ isOpen, onClose, title, children }) => {
 
 Modal.displayName = 'Modal';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default Modal;

--- a/src/components/shared/PageLoading.jsx
+++ b/src/components/shared/PageLoading.jsx
@@ -32,4 +32,7 @@ const PageLoading = () => {
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default PageLoading;

--- a/src/components/shared/PageWrapper.jsx
+++ b/src/components/shared/PageWrapper.jsx
@@ -77,4 +77,7 @@ const PageWrapper = ({ children }) => {
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default PageWrapper;

--- a/src/components/shared/PythonRunner.jsx
+++ b/src/components/shared/PythonRunner.jsx
@@ -255,4 +255,7 @@ const PythonRunner = ({ snippet }) => {
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default PythonRunner;

--- a/src/components/shared/RoastInterface.jsx
+++ b/src/components/shared/RoastInterface.jsx
@@ -252,4 +252,7 @@ const RoastInterface = ({ onClose, roastContent, onRoastComplete }) => {
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default RoastInterface;

--- a/src/components/shared/SEOHead.jsx
+++ b/src/components/shared/SEOHead.jsx
@@ -122,4 +122,7 @@ const SEOHead = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default SEOHead;

--- a/src/components/shared/ScrollReveal.jsx
+++ b/src/components/shared/ScrollReveal.jsx
@@ -100,4 +100,7 @@ const ScrollReveal = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default ScrollReveal;

--- a/src/components/shared/ScrollToTop.jsx
+++ b/src/components/shared/ScrollToTop.jsx
@@ -89,4 +89,7 @@ const ScrollToTop = React.memo(() => {
 
 ScrollToTop.displayName = 'ScrollToTop';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default ScrollToTop;

--- a/src/components/shared/SettingsModal.jsx
+++ b/src/components/shared/SettingsModal.jsx
@@ -224,4 +224,7 @@ const SettingsModal = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default SettingsModal;

--- a/src/components/shared/SyntaxHighlighter.jsx
+++ b/src/components/shared/SyntaxHighlighter.jsx
@@ -53,4 +53,7 @@ const SyntaxHighlighter = ({ code, language }) => {
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default SyntaxHighlighter;

--- a/src/components/shared/TechStackVisual.jsx
+++ b/src/components/shared/TechStackVisual.jsx
@@ -326,4 +326,7 @@ const TechStackVisual = () => {
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default TechStackVisual;

--- a/src/components/shared/TerminalMode.jsx
+++ b/src/components/shared/TerminalMode.jsx
@@ -403,4 +403,7 @@ Just kidding... but seriously, let's chat!
 
 TerminalMode.displayName = 'TerminalMode';
 
+/**
+ * @type {React.NamedExoticComponent}
+ */
 export default TerminalMode;

--- a/src/components/shared/ThemedButton.jsx
+++ b/src/components/shared/ThemedButton.jsx
@@ -95,4 +95,7 @@ const ThemedButton = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default ThemedButton;

--- a/src/components/shared/ThemedCard.jsx
+++ b/src/components/shared/ThemedCard.jsx
@@ -64,4 +64,7 @@ const ThemedCard = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default ThemedCard;

--- a/src/components/shared/ThemedChip.jsx
+++ b/src/components/shared/ThemedChip.jsx
@@ -78,4 +78,7 @@ const ThemedChip = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default ThemedChip;

--- a/src/components/shared/ThemedSectionHeading.jsx
+++ b/src/components/shared/ThemedSectionHeading.jsx
@@ -35,4 +35,7 @@ const ThemedSectionHeading = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default ThemedSectionHeading;

--- a/src/components/shared/ZigzagDivider.jsx
+++ b/src/components/shared/ZigzagDivider.jsx
@@ -69,4 +69,7 @@ const ZigzagDivider = ({
   );
 };
 
+/**
+ * @type {React.FC}
+ */
 export default ZigzagDivider;


### PR DESCRIPTION
Added missing JSDoc comments to un-exported components and `@type` annotations to default exports in games and shared components.

---
*PR created automatically by Jules for task [7312287777848011636](https://jules.google.com/task/7312287777848011636) started by @saint2706*