### PR TITLE
🛡️ Sentinel: Fix non-compliant UUIDv4 fallback in ChatInterface

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,8 @@ Resolved High severity vulnerability in a deep transitive dependency of Lighthou
   - Upgraded `postcss` to `8.5.10` using `pnpm install postcss@8.5.10`.
 - Mitigated a moderate XSS vulnerability in the ip-address dependency by enforcing version >=10.1.1 via pnpm.overrides in package.json.
   \n### 2026-05-19\n\n- **[SEC-DEP] Dependency updates**: Fixed moderate security vulnerabilities in `ws` and `brace-expansion` by overriding their minimum versions to `>=8.20.1` and `>=5.0.6` respectively via `pnpm.overrides` in `package.json`.
+
+### Security Improvement: Fallback UUIDv4 Generation
+
+- **Vulnerability / Warning**: `generateMessageId` in `src/components/shared/ChatInterface.jsx` was returning a pseudo-random hex string instead of a valid UUIDv4 when falling back to `crypto.getRandomValues`.
+- **Fix**: Replaced the arbitrary uint32 serialization with a standard-compliant UUIDv4 generator using `crypto.getRandomValues(new Uint8Array(16))`. Set the version bits to 4 and variant bits to 8/9/A/B, returning a standard 8-4-4-4-12 hex string to avoid potential collisions and ensure RFC 4122 compliance.

--- a/src/components/shared/ChatInterface.jsx
+++ b/src/components/shared/ChatInterface.jsx
@@ -54,9 +54,12 @@ const generateMessageId = () => {
       return crypto.randomUUID();
     }
     if (typeof crypto.getRandomValues === 'function') {
-      const array = new Uint32Array(4);
-      crypto.getRandomValues(array);
-      return Array.from(array, dec => dec.toString(16).padStart(8, '0')).join('-');
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
     }
   }
 

--- a/src/components/shared/ChatInterface.test.jsx
+++ b/src/components/shared/ChatInterface.test.jsx
@@ -443,7 +443,7 @@ describe('ChatInterface', () => {
       Object.defineProperty(global, 'crypto', {
         value: {
           getRandomValues: arr => {
-            for (let i = 0; i < arr.length; i++) arr[i] = 12345;
+            for (let i = 0; i < arr.length; i++) arr[i] = 12;
             return arr;
           },
         },


### PR DESCRIPTION
This PR addresses a security and robustness issue in the chat interface's message ID generation.

**Vulnerability / Issue**:
The `generateMessageId` function in `src/components/shared/ChatInterface.jsx` was returning a pseudo-random 35-character hex string (formatted as `8-8-8-8`) when falling back to `crypto.getRandomValues`. This format is not a valid UUID, lacks the required UUIDv4 version (4) and variant (8/9/A/B) bits, and could lead to collisions or validation failures downstream.

**Fix**:
Replaced the arbitrary `Uint32Array` serialization with a standard-compliant RFC 4122 UUIDv4 generator. It now uses `crypto.getRandomValues(new Uint8Array(16))`, correctly sets the version and variant bits, and returns a standard `8-4-4-4-12` formatted string. Also updated the corresponding Vitest mock to populate the 8-bit array properly.

---
*PR created automatically by Jules for task [12970720840428095911](https://jules.google.com/task/12970720840428095911) started by @saint2706*