### PR TITLE
🔍 Hunter: Fixed 1 errors - Removed duplicate import in Modal.test.jsx

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -139,3 +139,8 @@
 
 - **Fixed Duplicate Code**: Removed redundant `title` attributes from `src/components/layout/Navbar.jsx`, `src/components/pages/Projects.jsx`, `src/components/shared/Chatbot.jsx`, and `src/components/shared/TerminalMode.jsx` since they already had equivalent `aria-label` or visible text content.
 - **Verified**: Build, Lint, and Tests passed cleanly.
+
+## Session 26
+
+- **Fixed Duplicate Imports**: Removed duplicate import of `useTheme` from `src/components/shared/Modal.test.jsx`.
+- **Verified**: Build, Lint, Format, and Tests passed cleanly.

--- a/src/components/shared/Modal.test.jsx
+++ b/src/components/shared/Modal.test.jsx
@@ -1,9 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Modal from './Modal';
-import { ThemeProvider } from './theme-context';
-
-import { useTheme } from './theme-context';
+import { ThemeProvider, useTheme } from './theme-context';
 
 // Mock theme context since Modal uses it
 vi.mock('./theme-context', async () => {


### PR DESCRIPTION
As the Hunter agent, I identified a duplicate import of `useTheme` in `src/components/shared/Modal.test.jsx` and removed it. I also updated `.jules/hunter-progress.md` with details of the fix and ensured all builds, tests, and linters passed successfully.

---
*PR created automatically by Jules for task [8237519648903843891](https://jules.google.com/task/8237519648903843891) started by @saint2706*