### PR TITLE
📚 Docs: Add missing JSDoc comments to exported functions

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -121,3 +121,8 @@
 
 - Audited documentation for missing JSDoc return types.
 - Added `@returns {JSX.Element}` and `@returns {JSX.Element|null}` annotations to `Hero`, `SettingsModal`, `SEOHead`, `MarqueeTicker`, and `ZigzagDivider` components.
+
+## 2024-04-XX - Add missing JSDoc to exported functions
+
+- Added `@returns` JSDoc annotations to `__resetPyodideLoaderForTests` in `src/components/shared/pyodideLoader.js`.
+- Added `@returns` JSDoc annotations to `viewTransitionNavigate` in `src/navigation/viewTransitionNavigate.ts`.

--- a/src/components/shared/pyodideLoader.js
+++ b/src/components/shared/pyodideLoader.js
@@ -58,6 +58,7 @@ export const loadPyodide = async () => {
  * This is primarily used for testing purposes to ensure a clean state between tests.
  *
  * @private
+ * @returns {void}
  */
 export const __resetPyodideLoaderForTests = () => {
   pyodideInstance = null;

--- a/src/navigation/viewTransitionNavigate.ts
+++ b/src/navigation/viewTransitionNavigate.ts
@@ -90,6 +90,7 @@ export const shouldHandleClientNavigationKeydown = event => {
  * @param {TTo} to
  * @param {TOptions} [options]
  * @param {{ disabled?: boolean }} [config]
+ * @returns {void}
  */
 export const viewTransitionNavigate = (navigate, to, options, config = {}) => {
   if (typeof navigate !== 'function') return;


### PR DESCRIPTION
Adds missing JSDoc annotations to exported functions across the codebase.
Specifically:
- `__resetPyodideLoaderForTests` in `src/components/shared/pyodideLoader.js`
- `viewTransitionNavigate` in `src/navigation/viewTransitionNavigate.ts`

These changes resolve errors found while acting as the Docs agent.

---
*PR created automatically by Jules for task [10779413168091786921](https://jules.google.com/task/10779413168091786921) started by @saint2706*