### PR TITLE
🛡️ Sentinel: Upgrade ChatInterface UUID fallback to standard UUIDv4

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,4 @@ Resolved High severity vulnerability in a deep transitive dependency of Lighthou
   - Upgraded `postcss` to `8.5.10` using `pnpm install postcss@8.5.10`.
 - Mitigated a moderate XSS vulnerability in the ip-address dependency by enforcing version >=10.1.1 via pnpm.overrides in package.json.
   \n### 2026-05-19\n\n- **[SEC-DEP] Dependency updates**: Fixed moderate security vulnerabilities in `ws` and `brace-expansion` by overriding their minimum versions to `>=8.20.1` and `>=5.0.6` respectively via `pnpm.overrides` in `package.json`.
+- Updated ChatInterface UUID generator to standard UUIDv4 to improve fallback security

--- a/src/components/shared/ChatInterface.jsx
+++ b/src/components/shared/ChatInterface.jsx
@@ -54,9 +54,13 @@ const generateMessageId = () => {
       return crypto.randomUUID();
     }
     if (typeof crypto.getRandomValues === 'function') {
-      const array = new Uint32Array(4);
-      crypto.getRandomValues(array);
-      return Array.from(array, dec => dec.toString(16).padStart(8, '0')).join('-');
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      return Array.from(bytes, byte => byte.toString(16).padStart(2, '0'))
+        .join('')
+        .replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
     }
   }
 

--- a/src/components/shared/ChatInterface.test.jsx
+++ b/src/components/shared/ChatInterface.test.jsx
@@ -443,7 +443,7 @@ describe('ChatInterface', () => {
       Object.defineProperty(global, 'crypto', {
         value: {
           getRandomValues: arr => {
-            for (let i = 0; i < arr.length; i++) arr[i] = 12345;
+            for (let i = 0; i < arr.length; i++) arr[i] = 12;
             return arr;
           },
         },


### PR DESCRIPTION
This PR addresses a minor security issue where the UUID fallback generator in `ChatInterface.jsx` was producing pseudo-random hyphenated strings rather than standard-compliant UUIDv4 values.

- Switched from `Uint32Array` to `Uint8Array` in `generateMessageId`.
- Correctly sets the version 4 (`0x40`) and variant 1 (`0x80`) bits according to the UUID standard.
- Formats the resulting bytes into an 8-4-4-4-12 hex string.
- Updated the associated Vitest mocks in `ChatInterface.test.jsx` to prevent out-of-bounds issues when filling the `Uint8Array`.
- Logged the update in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11450596635011028040](https://jules.google.com/task/11450596635011028040) started by @saint2706*