### PR TITLE
Add difficulty levels to Whack-a-Mole, Lights Out, and Minesweeper

### DIFF
--- a/src/components/games/LightsOut.jsx
+++ b/src/components/games/LightsOut.jsx
@@ -21,37 +21,61 @@ import { useTheme } from '../shared/theme-context';
 import { getGameThemeStyles } from './gameThemeStyles';
 import { safeGetLocalStorage, safeSetLocalStorage } from '../../utils/storage';
 
-const SIZE = 5;
+const DIFFICULTY_SETTINGS = {
+  easy: {
+    label: 'Easy',
+    color: 'bg-fun-yellow',
+    text: 'text-black',
+    size: 4,
+    minToggles: 5,
+    toggleRange: 5, // toggles land in [minToggles, minToggles + toggleRange - 1]
+  },
+  medium: {
+    label: 'Medium',
+    color: 'bg-accent',
+    text: 'text-white',
+    size: 5,
+    minToggles: 8,
+    toggleRange: 8,
+  },
+  hard: {
+    label: 'Hard',
+    color: 'bg-fun-pink',
+    text: 'text-white',
+    size: 6,
+    minToggles: 12,
+    toggleRange: 9,
+  },
+};
 
 /**
  * Creates a solvable puzzle by starting from "all off" and applying random toggles.
  * This guarantees the puzzle is solvable.
  */
-const createPuzzle = () => {
-  const grid = Array.from({ length: SIZE }, () => Array(SIZE).fill(false));
+const createPuzzle = ({ size, minToggles, toggleRange }) => {
+  const grid = Array.from({ length: size }, () => Array(size).fill(false));
 
-  // Apply 8-15 random toggles
-  const toggles = 8 + Math.floor(Math.random() * 8);
+  const toggles = minToggles + Math.floor(Math.random() * toggleRange);
   for (let t = 0; t < toggles; t++) {
-    const r = Math.floor(Math.random() * SIZE);
-    const c = Math.floor(Math.random() * SIZE);
+    const r = Math.floor(Math.random() * size);
+    const c = Math.floor(Math.random() * size);
     // Toggle cell and neighbours
     grid[r][c] = !grid[r][c];
     if (r > 0) grid[r - 1][c] = !grid[r - 1][c];
-    if (r < SIZE - 1) grid[r + 1][c] = !grid[r + 1][c];
+    if (r < size - 1) grid[r + 1][c] = !grid[r + 1][c];
     if (c > 0) grid[r][c - 1] = !grid[r][c - 1];
-    if (c < SIZE - 1) grid[r][c + 1] = !grid[r][c + 1];
+    if (c < size - 1) grid[r][c + 1] = !grid[r][c + 1];
   }
 
   // Ensure at least some lights are on
   if (grid.every(row => row.every(cell => !cell))) {
     // All off already — toggle center
-    const mid = Math.floor(SIZE / 2);
+    const mid = Math.floor(size / 2);
     grid[mid][mid] = true;
     if (mid > 0) grid[mid - 1][mid] = true;
-    if (mid < SIZE - 1) grid[mid + 1][mid] = true;
+    if (mid < size - 1) grid[mid + 1][mid] = true;
     if (mid > 0) grid[mid][mid - 1] = true;
-    if (mid < SIZE - 1) grid[mid][mid + 1] = true;
+    if (mid < size - 1) grid[mid][mid + 1] = true;
   }
 
   return grid;
@@ -109,13 +133,21 @@ const LightsOut = React.memo(() => {
   const { theme } = useTheme();
   const isLiquid = theme === 'liquid';
   const ui = getGameThemeStyles(isLiquid);
+  const [difficulty, setDifficulty] = useState('medium');
+  const settings = DIFFICULTY_SETTINGS[difficulty];
+  const size = settings.size;
   const [gameState, setGameState] = useState('idle'); // idle | playing | won
-  const [grid, setGrid] = useState(createPuzzle);
+  const [grid, setGrid] = useState(() => createPuzzle(DIFFICULTY_SETTINGS.medium));
   const [moves, setMoves] = useState(0);
-  const [bestScore, setBestScore] = useState(() => {
-    const s = safeGetLocalStorage('lightsOutBest');
-    return s ? parseInt(s, 10) : null;
+  const [bestScores, setBestScores] = useState(() => {
+    const scores = {};
+    Object.keys(DIFFICULTY_SETTINGS).forEach(key => {
+      const s = safeGetLocalStorage(`lightsOutBest_${key}`);
+      scores[key] = s ? parseInt(s, 10) : null;
+    });
+    return scores;
   });
+  const bestScore = bestScores[difficulty];
   const [focusR, setFocusR] = useState(0);
   const [focusC, setFocusC] = useState(0);
 
@@ -127,9 +159,9 @@ const LightsOut = React.memo(() => {
       const nextGrid = grid.map(row => [...row]);
       nextGrid[r][c] = !nextGrid[r][c];
       if (r > 0) nextGrid[r - 1][c] = !nextGrid[r - 1][c];
-      if (r < SIZE - 1) nextGrid[r + 1][c] = !nextGrid[r + 1][c];
+      if (r < size - 1) nextGrid[r + 1][c] = !nextGrid[r + 1][c];
       if (c > 0) nextGrid[r][c - 1] = !nextGrid[r][c - 1];
-      if (c < SIZE - 1) nextGrid[r][c + 1] = !nextGrid[r][c + 1];
+      if (c < size - 1) nextGrid[r][c + 1] = !nextGrid[r][c + 1];
 
       setGrid(nextGrid);
 
@@ -141,20 +173,30 @@ const LightsOut = React.memo(() => {
       if (allOff) {
         setGameState('won');
         if (!bestScore || newMoves < bestScore) {
-          setBestScore(newMoves);
-          safeSetLocalStorage('lightsOutBest', newMoves.toString());
+          setBestScores(prev => ({ ...prev, [difficulty]: newMoves }));
+          safeSetLocalStorage(`lightsOutBest_${difficulty}`, newMoves.toString());
         }
       }
     },
-    [gameState, grid, moves, bestScore]
+    [gameState, grid, moves, bestScore, size, difficulty]
   );
 
   const startGame = useCallback(() => {
-    setGrid(createPuzzle());
+    setGrid(createPuzzle(settings));
     setMoves(0);
     setFocusR(0);
     setFocusC(0);
     setGameState('playing');
+  }, [settings]);
+
+  const changeDifficulty = useCallback(newDifficulty => {
+    const newSettings = DIFFICULTY_SETTINGS[newDifficulty];
+    setDifficulty(newDifficulty);
+    setGrid(createPuzzle(newSettings));
+    setMoves(0);
+    setFocusR(0);
+    setFocusC(0);
+    setGameState('idle');
   }, []);
 
   // Keyboard navigation
@@ -167,7 +209,7 @@ const LightsOut = React.memo(() => {
 
       switch (e.key) {
         case 'ArrowRight':
-          c = Math.min(SIZE - 1, c + 1);
+          c = Math.min(size - 1, c + 1);
           handled = true;
           break;
         case 'ArrowLeft':
@@ -175,7 +217,7 @@ const LightsOut = React.memo(() => {
           handled = true;
           break;
         case 'ArrowDown':
-          r = Math.min(SIZE - 1, r + 1);
+          r = Math.min(size - 1, r + 1);
           handled = true;
           break;
         case 'ArrowUp':
@@ -198,7 +240,7 @@ const LightsOut = React.memo(() => {
         setFocusC(c);
       }
     },
-    [gameState, focusR, focusC, toggleCell]
+    [gameState, focusR, focusC, toggleCell, size]
   );
 
   const lightsOn = grid.flat().filter(Boolean).length;
@@ -214,6 +256,33 @@ const LightsOut = React.memo(() => {
     <div className="flex flex-col items-center gap-6">
       <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
         {getAnnouncement()}
+      </div>
+
+      {/* Difficulty Selector */}
+      <div className="flex gap-2" role="group" aria-label="Select difficulty level">
+        {Object.entries(DIFFICULTY_SETTINGS).map(([id, config]) => (
+          <button
+            key={id}
+            onClick={() => changeDifficulty(id)}
+            aria-pressed={difficulty === id}
+            aria-label={`Set difficulty to ${config.label}`}
+            className={`px-4 py-2 font-heading font-bold text-sm border-[3px] border-[color:var(--color-border)] cursor-pointer transition-transform motion-reduce:transform-none motion-reduce:transition-none
+              ${
+                difficulty === id
+                  ? `${config.color} ${config.text} ${isLiquid ? 'scale-[1.01] border border-[color:var(--border-soft)] rounded-xl' : '-translate-x-0.5 -translate-y-0.5'}`
+                  : `${isLiquid ? 'lg-surface-2 rounded-xl text-primary hover:brightness-110' : 'bg-card text-primary hover:-translate-x-0.5 hover:-translate-y-0.5'}`
+              }`}
+            style={{
+              boxShadow: isLiquid
+                ? undefined
+                : difficulty === id
+                  ? 'var(--nb-shadow-hover)'
+                  : '2px 2px 0 var(--color-border)',
+            }}
+          >
+            {config.label}
+          </button>
+        ))}
       </div>
 
       {/* Score board */}
@@ -272,7 +341,7 @@ const LightsOut = React.memo(() => {
         >
           <div
             className="grid gap-2 outline-none"
-            style={{ gridTemplateColumns: `repeat(${SIZE}, 1fr)` }}
+            style={{ gridTemplateColumns: `repeat(${size}, 1fr)` }}
             role="grid"
             aria-label="Lights Out puzzle grid"
             onKeyDown={handleKeyDown}

--- a/src/components/games/Minesweeper.jsx
+++ b/src/components/games/Minesweeper.jsx
@@ -20,17 +20,26 @@ import { useTheme } from '../shared/theme-context';
 import { getGameThemeStyles } from './gameThemeStyles';
 import { safeGetLocalStorage, safeSetLocalStorage } from '../../utils/storage';
 
-const ROWS = 9;
-const COLS = 9;
-const MINES = 10;
+const DIFFICULTY_SETTINGS = {
+  easy: { label: 'Easy', color: 'bg-fun-yellow', text: 'text-black', rows: 9, cols: 9, mines: 10 },
+  medium: {
+    label: 'Medium',
+    color: 'bg-accent',
+    text: 'text-white',
+    rows: 12,
+    cols: 12,
+    mines: 20,
+  },
+  hard: { label: 'Hard', color: 'bg-fun-pink', text: 'text-white', rows: 16, cols: 16, mines: 40 },
+};
 
 /**
  * Creates an empty board.
  * Each cell: { mine, revealed, flagged, adjacent }
  */
-const createEmptyBoard = () =>
-  Array.from({ length: ROWS }, () =>
-    Array.from({ length: COLS }, () => ({
+const createEmptyBoard = (rows, cols) =>
+  Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({
       mine: false,
       revealed: false,
       flagged: false,
@@ -41,27 +50,27 @@ const createEmptyBoard = () =>
 /**
  * Places mines randomly, avoiding the first-click cell and its neighbours.
  */
-const placeMines = (board, safeR, safeC) => {
+const placeMines = (board, safeR, safeC, rows, cols, mines) => {
   const b = board.map(row => row.map(cell => ({ ...cell })));
   let placed = 0;
-  while (placed < MINES) {
-    const r = Math.floor(Math.random() * ROWS);
-    const c = Math.floor(Math.random() * COLS);
+  while (placed < mines) {
+    const r = Math.floor(Math.random() * rows);
+    const c = Math.floor(Math.random() * cols);
     if (b[r][c].mine) continue;
     if (Math.abs(r - safeR) <= 1 && Math.abs(c - safeC) <= 1) continue;
     b[r][c].mine = true;
     placed++;
   }
   // Compute adjacency counts
-  for (let r = 0; r < ROWS; r++) {
-    for (let c = 0; c < COLS; c++) {
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
       if (b[r][c].mine) continue;
       let count = 0;
       for (let dr = -1; dr <= 1; dr++) {
         for (let dc = -1; dc <= 1; dc++) {
           const nr = r + dr;
           const nc = c + dc;
-          if (nr >= 0 && nr < ROWS && nc >= 0 && nc < COLS && b[nr][nc].mine) count++;
+          if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && b[nr][nc].mine) count++;
         }
       }
       b[r][c].adjacent = count;
@@ -73,12 +82,12 @@ const placeMines = (board, safeR, safeC) => {
 /**
  * Flood-fill reveal for empty cells.
  */
-const floodReveal = (board, r, c) => {
+const floodReveal = (board, r, c, rows, cols) => {
   const b = board.map(row => row.map(cell => ({ ...cell })));
   const stack = [[r, c]];
   while (stack.length) {
     const [cr, cc] = stack.pop();
-    if (cr < 0 || cr >= ROWS || cc < 0 || cc >= COLS) continue;
+    if (cr < 0 || cr >= rows || cc < 0 || cc >= cols) continue;
     if (b[cr][cc].revealed || b[cr][cc].flagged || b[cr][cc].mine) continue;
     b[cr][cc].revealed = true;
     if (b[cr][cc].adjacent === 0) {
@@ -221,28 +230,35 @@ const Minesweeper = React.memo(() => {
   const { theme } = useTheme();
   const isLiquid = theme === 'liquid';
   const ui = React.useMemo(() => getGameThemeStyles(isLiquid), [isLiquid]);
+  const [difficulty, setDifficulty] = useState('easy');
+  const { rows, cols, mines } = DIFFICULTY_SETTINGS[difficulty];
   const [gameState, setGameState] = useState('idle'); // idle | playing | won | lost
-  const [board, setBoard] = useState(createEmptyBoard);
+  const [board, setBoard] = useState(() => createEmptyBoard(rows, cols));
   const [firstClick, setFirstClick] = useState(true);
   const [flagCount, setFlagCount] = useState(0);
 
   // Performance Optimization: Moved timer state to TimerDisplay component
-  // to prevent re-rendering the entire 9x9 grid every second.
+  // to prevent re-rendering the entire grid every second.
   const [startTime, setStartTime] = useState(null);
   const [finalTime, setFinalTime] = useState(null);
   const startTimeRef = useRef(null);
 
-  const [bestTime, setBestTime] = useState(() => {
-    const s = safeGetLocalStorage('minesweeperBest');
-    return s ? parseInt(s, 10) : null;
+  const [bestTimes, setBestTimes] = useState(() => {
+    const times = {};
+    Object.keys(DIFFICULTY_SETTINGS).forEach(key => {
+      const s = safeGetLocalStorage(`minesweeperBest_${key}`);
+      times[key] = s ? parseInt(s, 10) : null;
+    });
+    return times;
   });
+  const bestTime = bestTimes[difficulty];
   const [focusR, setFocusR] = useState(0);
   const [focusC, setFocusC] = useState(0);
 
   const checkWin = useCallback(
     b => {
-      for (let r = 0; r < ROWS; r++) {
-        for (let c = 0; c < COLS; c++) {
+      for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
           if (!b[r][c].mine && !b[r][c].revealed) return false;
         }
       }
@@ -251,12 +267,12 @@ const Minesweeper = React.memo(() => {
       setFinalTime(duration);
 
       if (!bestTime || duration < bestTime) {
-        setBestTime(duration);
-        safeSetLocalStorage('minesweeperBest', duration.toString());
+        setBestTimes(prev => ({ ...prev, [difficulty]: duration }));
+        safeSetLocalStorage(`minesweeperBest_${difficulty}`, duration.toString());
       }
       return true;
     },
-    [bestTime]
+    [bestTime, rows, cols, difficulty]
   );
 
   const revealCell = useCallback(
@@ -273,7 +289,7 @@ const Minesweeper = React.memo(() => {
       setBoard(prev => {
         let b = prev;
         if (firstClick) {
-          b = placeMines(prev, r, c);
+          b = placeMines(prev, r, c, rows, cols, mines);
           setFirstClick(false);
           setGameState('playing');
         }
@@ -289,14 +305,14 @@ const Minesweeper = React.memo(() => {
           return lost;
         }
 
-        const newBoard = floodReveal(b, r, c);
+        const newBoard = floodReveal(b, r, c, rows, cols);
         if (checkWin(newBoard)) {
           setGameState('won');
         }
         return newBoard;
       });
     },
-    [gameState, firstClick, checkWin]
+    [gameState, firstClick, checkWin, rows, cols, mines]
   );
 
   const toggleFlag = useCallback(
@@ -315,7 +331,7 @@ const Minesweeper = React.memo(() => {
   );
 
   const startGame = useCallback(() => {
-    setBoard(createEmptyBoard());
+    setBoard(createEmptyBoard(rows, cols));
     setFirstClick(true);
     setFlagCount(0);
 
@@ -329,6 +345,20 @@ const Minesweeper = React.memo(() => {
     setFocusC(0);
     // Transition to a "ready" idle — first click will start
     setTimeout(() => setGameState('idle'), 0);
+  }, [rows, cols]);
+
+  const changeDifficulty = useCallback(newDifficulty => {
+    const newSettings = DIFFICULTY_SETTINGS[newDifficulty];
+    setDifficulty(newDifficulty);
+    setBoard(createEmptyBoard(newSettings.rows, newSettings.cols));
+    setFirstClick(true);
+    setFlagCount(0);
+    setStartTime(null);
+    setFinalTime(null);
+    startTimeRef.current = null;
+    setGameState('idle');
+    setFocusR(0);
+    setFocusC(0);
   }, []);
 
   // Update focus state when a cell is focused via mouse/tab
@@ -348,7 +378,7 @@ const Minesweeper = React.memo(() => {
 
       switch (e.key) {
         case 'ArrowRight':
-          c = Math.min(COLS - 1, c + 1);
+          c = Math.min(cols - 1, c + 1);
           handled = true;
           break;
         case 'ArrowLeft':
@@ -356,7 +386,7 @@ const Minesweeper = React.memo(() => {
           handled = true;
           break;
         case 'ArrowDown':
-          r = Math.min(ROWS - 1, r + 1);
+          r = Math.min(rows - 1, r + 1);
           handled = true;
           break;
         case 'ArrowUp':
@@ -386,7 +416,7 @@ const Minesweeper = React.memo(() => {
         if (nextCell) nextCell.focus();
       }
     },
-    [gameState, focusR, focusC, revealCell, toggleFlag]
+    [gameState, focusR, focusC, revealCell, toggleFlag, rows, cols]
   );
 
   const getAnnouncement = () => {
@@ -395,7 +425,7 @@ const Minesweeper = React.memo(() => {
     const timeToAnnounce = finalTime !== null ? finalTime : 0;
     if (gameState === 'won') return `You won in ${timeToAnnounce} seconds!`;
     if (gameState === 'lost') return 'Game over! You hit a mine.';
-    return `Playing Minesweeper. Flags: ${flagCount}/${MINES}.`;
+    return `Playing Minesweeper. Flags: ${flagCount}/${mines}.`;
   };
 
   const isGameOver = gameState === 'won' || gameState === 'lost';
@@ -406,13 +436,40 @@ const Minesweeper = React.memo(() => {
         {getAnnouncement()}
       </div>
 
+      {/* Difficulty Selector */}
+      <div className="flex gap-2" role="group" aria-label="Select difficulty level">
+        {Object.entries(DIFFICULTY_SETTINGS).map(([id, config]) => (
+          <button
+            key={id}
+            onClick={() => changeDifficulty(id)}
+            aria-pressed={difficulty === id}
+            aria-label={`Set difficulty to ${config.label}`}
+            className={`px-4 py-2 font-heading font-bold text-sm border-[3px] border-[color:var(--color-border)] cursor-pointer transition-transform motion-reduce:transform-none motion-reduce:transition-none
+              ${
+                difficulty === id
+                  ? `${config.color} ${config.text} ${isLiquid ? 'scale-[1.01] border border-[color:var(--border-soft)] rounded-xl' : '-translate-x-0.5 -translate-y-0.5'}`
+                  : `${isLiquid ? 'lg-surface-2 rounded-xl text-primary hover:brightness-110' : 'bg-card text-primary hover:-translate-x-0.5 hover:-translate-y-0.5'}`
+              }`}
+            style={{
+              boxShadow: isLiquid
+                ? undefined
+                : difficulty === id
+                  ? 'var(--nb-shadow-hover)'
+                  : '2px 2px 0 var(--color-border)',
+            }}
+          >
+            {config.label}
+          </button>
+        ))}
+      </div>
+
       {/* Status bar */}
       <div className={ui.scoreboard} style={ui.style.raised}>
         <div className="flex items-center gap-2 px-4">
           <Flag size={16} className="text-fun-pink" aria-hidden="true" />
           <div>
             <div className="text-sm md:text-xs text-secondary font-heading">Mines</div>
-            <div className="text-2xl font-heading font-bold text-fun-pink">{MINES - flagCount}</div>
+            <div className="text-2xl font-heading font-bold text-fun-pink">{mines - flagCount}</div>
           </div>
         </div>
         <div className={ui.separator} />
@@ -446,7 +503,7 @@ const Minesweeper = React.memo(() => {
         >
           <div
             className="grid gap-[2px] outline-none"
-            style={{ gridTemplateColumns: `repeat(${COLS}, 1fr)` }}
+            style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
             role="grid"
             aria-label="Minesweeper game board"
             onKeyDown={handleKeyDown}

--- a/src/components/games/Minesweeper.test.jsx
+++ b/src/components/games/Minesweeper.test.jsx
@@ -395,7 +395,7 @@ describe('Minesweeper Game', () => {
 
   it('displays the best time from localStorage', async () => {
     localStorageMock.getItem.mockImplementation(key => {
-      if (key === 'minesweeperBest') return '15';
+      if (key === 'minesweeperBest_easy') return '15';
       return null;
     });
     renderWithTheme(<Minesweeper />);

--- a/src/components/games/WhackAMole.jsx
+++ b/src/components/games/WhackAMole.jsx
@@ -22,9 +22,33 @@ import { safeGetLocalStorage, safeSetLocalStorage } from '../../utils/storage';
 
 const GRID_SIZE = 9; // 3×3
 const GAME_DURATION = 30; // seconds
-const INITIAL_MOLE_TIME = 1200; // ms mole stays visible
-const MIN_MOLE_TIME = 400;
-const SPAWN_INTERVAL = 800; // ms between spawns
+
+const DIFFICULTY_SETTINGS = {
+  easy: {
+    label: 'Easy',
+    color: 'bg-fun-yellow',
+    text: 'text-black',
+    moleTime: 1600, // ms mole stays visible
+    minMoleTime: 700,
+    spawnInterval: 1000, // ms between spawns
+  },
+  medium: {
+    label: 'Medium',
+    color: 'bg-accent',
+    text: 'text-white',
+    moleTime: 1200,
+    minMoleTime: 400,
+    spawnInterval: 800,
+  },
+  hard: {
+    label: 'Hard',
+    color: 'bg-fun-pink',
+    text: 'text-white',
+    moleTime: 850,
+    minMoleTime: 300,
+    spawnInterval: 550,
+  },
+};
 
 const MoleHole = React.memo(
   ({ index, isActive, isWhacked, isLiquid, gameState, ui, shouldReduceMotion, onClick }) => {
@@ -93,15 +117,22 @@ const WhackAMole = React.memo(() => {
   const { theme } = useTheme();
   const isLiquid = theme === 'liquid';
   const ui = getGameThemeStyles(isLiquid);
+  const [difficulty, setDifficulty] = useState('medium');
   const [gameState, setGameState] = useState('idle'); // idle | playing | gameOver
   const [score, setScore] = useState(0);
   const [timeLeft, setTimeLeft] = useState(GAME_DURATION);
   const [activeMoles, setActiveMoles] = useState(new Set());
   const [whackedMoles, setWhackedMoles] = useState(new Set()); // brief "hit" feedback
-  const [highScore, setHighScore] = useState(() => {
-    const s = safeGetLocalStorage('whackHighScore');
-    return s ? parseInt(s, 10) : 0;
+  const [highScores, setHighScores] = useState(() => {
+    const scores = {};
+    Object.keys(DIFFICULTY_SETTINGS).forEach(key => {
+      const s = safeGetLocalStorage(`whackHighScore_${key}`);
+      scores[key] = s ? parseInt(s, 10) : 0;
+    });
+    return scores;
   });
+  const highScore = highScores[difficulty];
+  const settings = DIFFICULTY_SETTINGS[difficulty];
   const timerRef = useRef(null);
   const spawnRef = useRef(null);
   const moleTimersRef = useRef({});
@@ -118,12 +149,12 @@ const WhackAMole = React.memo(() => {
     clearAllTimers();
     setActiveMoles(new Set());
     const finalScore = scoreRef.current;
-    if (finalScore > highScore) {
-      setHighScore(finalScore);
-      safeSetLocalStorage('whackHighScore', finalScore.toString());
+    if (finalScore > highScores[difficulty]) {
+      setHighScores(prev => ({ ...prev, [difficulty]: finalScore }));
+      safeSetLocalStorage(`whackHighScore_${difficulty}`, finalScore.toString());
     }
     setGameState('gameOver');
-  }, [clearAllTimers, highScore]);
+  }, [clearAllTimers, highScores, difficulty]);
 
   const spawnMole = useCallback(() => {
     const available = [];
@@ -134,7 +165,7 @@ const WhackAMole = React.memo(() => {
 
     const hole = available[Math.floor(Math.random() * available.length)];
     const elapsed = GAME_DURATION - timeLeft;
-    const moleTime = Math.max(MIN_MOLE_TIME, INITIAL_MOLE_TIME - elapsed * 25);
+    const moleTime = Math.max(settings.minMoleTime, settings.moleTime - elapsed * 25);
 
     setActiveMoles(prev => new Set([...prev, hole]));
 
@@ -146,7 +177,7 @@ const WhackAMole = React.memo(() => {
       });
       delete moleTimersRef.current[hole];
     }, moleTime);
-  }, [activeMoles, timeLeft]);
+  }, [activeMoles, timeLeft, settings]);
 
   const startGame = useCallback(() => {
     clearAllTimers();
@@ -157,6 +188,20 @@ const WhackAMole = React.memo(() => {
     setWhackedMoles(new Set());
     setGameState('playing');
   }, [clearAllTimers]);
+
+  const changeDifficulty = useCallback(
+    newDifficulty => {
+      clearAllTimers();
+      setDifficulty(newDifficulty);
+      setGameState('idle');
+      setScore(0);
+      scoreRef.current = 0;
+      setTimeLeft(GAME_DURATION);
+      setActiveMoles(new Set());
+      setWhackedMoles(new Set());
+    },
+    [clearAllTimers]
+  );
 
   // Timer countdown
   useEffect(() => {
@@ -177,10 +222,10 @@ const WhackAMole = React.memo(() => {
   // Mole spawning
   useEffect(() => {
     if (gameState === 'playing') {
-      spawnRef.current = setInterval(spawnMole, SPAWN_INTERVAL);
+      spawnRef.current = setInterval(spawnMole, settings.spawnInterval);
       return () => clearInterval(spawnRef.current);
     }
-  }, [gameState, spawnMole]);
+  }, [gameState, spawnMole, settings]);
 
   const whackMole = useCallback(
     hole => {
@@ -246,6 +291,33 @@ const WhackAMole = React.memo(() => {
     <div className="flex flex-col items-center gap-6">
       <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
         {getAnnouncement()}
+      </div>
+
+      {/* Difficulty Selector */}
+      <div className="flex gap-2" role="group" aria-label="Select difficulty level">
+        {Object.entries(DIFFICULTY_SETTINGS).map(([id, config]) => (
+          <button
+            key={id}
+            onClick={() => changeDifficulty(id)}
+            aria-pressed={difficulty === id}
+            aria-label={`Set difficulty to ${config.label}`}
+            className={`px-4 py-2 font-heading font-bold text-sm border-[3px] border-[color:var(--color-border)] cursor-pointer transition-transform motion-reduce:transform-none motion-reduce:transition-none
+              ${
+                difficulty === id
+                  ? `${config.color} ${config.text} ${isLiquid ? 'scale-[1.01] border border-[color:var(--border-soft)] rounded-xl' : '-translate-x-0.5 -translate-y-0.5'}`
+                  : `${isLiquid ? 'lg-surface-2 rounded-xl text-primary hover:brightness-110' : 'bg-card text-primary hover:-translate-x-0.5 hover:-translate-y-0.5'}`
+              }`}
+            style={{
+              boxShadow: isLiquid
+                ? undefined
+                : difficulty === id
+                  ? 'var(--nb-shadow-hover)'
+                  : '2px 2px 0 var(--color-border)',
+            }}
+          >
+            {config.label}
+          </button>
+        ))}
       </div>
 
       {/* Status bar */}

--- a/src/components/games/WhackAMole.test.jsx
+++ b/src/components/games/WhackAMole.test.jsx
@@ -337,7 +337,7 @@ describe('WhackAMole', () => {
     });
 
     // Verify local storage is updated and high score is shown
-    expect(localStorage.getItem('whackHighScore')).toBe('1');
+    expect(localStorage.getItem('whackHighScore_medium')).toBe('1');
     expect(screen.getAllByText(/New High Score!/i).length).toBeGreaterThan(0);
 
     await act(async () => {
@@ -347,7 +347,7 @@ describe('WhackAMole', () => {
 
   it('does not record a new high score if score is not strictly greater', async () => {
     // Preset high score to 10
-    localStorage.setItem('whackHighScore', '10');
+    localStorage.setItem('whackHighScore_medium', '10');
     render(<WhackAMole />);
 
     await act(async () => {
@@ -362,7 +362,7 @@ describe('WhackAMole', () => {
     });
 
     // Local storage should still be 10, not 0
-    expect(localStorage.getItem('whackHighScore')).toBe('10');
+    expect(localStorage.getItem('whackHighScore_medium')).toBe('10');
     expect(screen.queryByText(/New High Score!/i)).not.toBeInTheDocument();
 
     await act(async () => {


### PR DESCRIPTION
## Summary
- Added Easy / Medium / Hard difficulty selectors to Whack-a-Mole, Lights Out, and Minesweeper, matching the existing selector pattern used in Tic Tac Toe.
- **Whack-a-Mole**: difficulty scales mole visibility duration and spawn rate (Easy: slower/longer, Hard: faster/shorter). Grid stays 3×3 and the game stays 30s across difficulties.
- **Lights Out**: difficulty scales grid size and puzzle scramble depth (Easy: 4×4, Medium: 5×5 (previous default), Hard: 6×6).
- **Minesweeper**: difficulty scales board size and mine count (Easy: 9×9/10 mines (previous default), Medium: 12×12/20 mines, Hard: 16×16/40 mines).
- High scores / best times are now tracked per-difficulty in localStorage (e.g. `whackHighScore_medium`, `lightsOutBest_hard`, `minesweeperBest_easy`) since scores/times aren't comparable across different board sizes or speeds.
- Default difficulty for each game matches its previous fixed behavior exactly, so existing players' saved high scores under the old keys simply won't carry over to the new per-difficulty keys (a one-time reset).

## Test plan
- [x] `pnpm exec vitest run` — full suite (411 tests) passes, including updated assertions for the new per-difficulty localStorage keys.
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — succeeds.
- [x] Manually exercised all three games in a running dev server (Playwright-driven): confirmed difficulty selector renders, switching difficulty resets the board, and Minesweeper/Lights Out board sizes update correctly (81 → 144 → 256 cells; 16 → 25 → 36 cells) while Whack-a-Mole keeps its 9-hole grid and only changes mole timing.


---
_Generated by [Claude Code](https://claude.ai/code/session_0175CvUS43DqpRjJdtuYX2av)_