### PR TITLE
Polish Playground UI: run button contrast, copy icon, card spacing, scrollbar

### DIFF
--- a/src/components/pages/Playground.jsx
+++ b/src/components/pages/Playground.jsx
@@ -428,7 +428,7 @@ const SnippetCard = React.memo(
           </p>
 
           {/* Code Block */}
-          <div className="relative mb-4 flex-grow nb-scrollbar overflow-auto max-h-64 min-h-[12rem]">
+          <div className="relative mb-4 nb-scrollbar overflow-y-auto overflow-x-hidden max-h-64">
             <Suspense
               fallback={
                 <div className="h-48 bg-card animate-pulse rounded-nb border-2 border-[color:var(--color-border)]" />
@@ -440,8 +440,10 @@ const SnippetCard = React.memo(
             {/* Copy Button */}
             <button
               onClick={() => onCopy(snippet.code, snippet.id)}
-              className={`group absolute top-2 right-2 p-2 rounded-md border-2 border-[color:var(--color-border)] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)] focus-visible:ring-offset-2 ${
-                isCopied ? 'bg-green-500 text-white' : 'bg-card text-primary hover:bg-fun-yellow'
+              className={`group absolute top-2 right-2 p-2 rounded-md border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--focus-ring)] focus-visible:ring-offset-2 ${
+                isCopied
+                  ? 'bg-green-500 border-green-500 text-white'
+                  : 'bg-white/10 border-white/20 text-white/80 backdrop-blur-sm hover:bg-fun-yellow hover:text-primary hover:border-[color:var(--color-border)]'
               }`}
               aria-label={isCopied ? 'Copied!' : `Copy ${snippet.title} code`}
             >

--- a/src/components/shared/PythonRunner.jsx
+++ b/src/components/shared/PythonRunner.jsx
@@ -203,7 +203,7 @@ const PythonRunner = ({ snippet }) => {
             aria-label={isRunning ? 'Running Python code' : 'Run Python code'}
             className={`flex items-center gap-2 px-4 py-2 font-heading font-bold text-sm border-2 border-[color:var(--color-border)] rounded-md transition-all ${
               isRunning || !pyodideReady
-                ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                ? 'bg-gray-200 text-gray-700 cursor-not-allowed'
                 : 'bg-accent text-white hover:-translate-x-0.5 hover:-translate-y-0.5'
             }`}
             style={{


### PR DESCRIPTION
## Summary

Four small visual fixes to the `/playground` page, based on a review of the rendered page:

- **Run button text unreadable**: the Python Runner's "Run" button used `text-gray-500` on `bg-gray-300` while Pyodide is still loading (the state you see right when the modal opens) — contrast was too weak to read. Darkened the disabled-state text to `text-gray-700`.
- **Copy-code icon looked ugly**: it was an opaque white square with a border floating on top of the dark code block. Made it translucent (`bg-white/10` + `backdrop-blur-sm`) so it blends into the code block until hovered, then pops to the existing yellow hover style.
- **Large empty space in snippet cards**: the code block wrapper had a forced `min-h-[12rem]`, so short snippets left a big blank gap between the code and the tags/buttons below. Removed the forced minimum height so the box hugs its content; the grid's `mt-auto` action-button row still keeps card footers aligned.
- **Stray neu-brutal horizontal scrollbar**: the code block wrapper used `overflow-auto` (both axes) while the inner `<pre>` also scrolls horizontally on its own for long lines. The nested scrollbar's reserved width made the outer wrapper register a few pixels of horizontal overflow too, so the chunky neubrutalist scrollbar rendered across the bottom of nearly every card even when it wasn't needed. Switched the wrapper to vertical-only scrolling (`overflow-y-auto overflow-x-hidden`); the `<pre>` still scrolls horizontally on its own for long code lines.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm vitest run src/components/pages/Playground.test.jsx` passes (6/6)
- [x] Verified visually via Playwright screenshots: cards are noticeably more compact, copy icon blends into the code block and highlights on hover, Run button text is legible in both loading and ready states, and no horizontal scrollbar artifact appears on any snippet card


---
_Generated by [Claude Code](https://claude.ai/code/session_01XszfoYCfjvW6kHTrob1k7r)_