### PR TITLE
Add "How to Play" instructions for all games

### DIFF
--- a/src/components/games/GameInstructions.jsx
+++ b/src/components/games/GameInstructions.jsx
@@ -1,0 +1,111 @@
+/**
+ * @fileoverview GameInstructions — Collapsible "How to Play" panel for the Games page.
+ *
+ * Renders a themed disclosure button that expands to show the goal and
+ * step-by-step instructions (including keyboard controls) for the currently
+ * selected game. Instructions are data-driven via the GAME_INSTRUCTIONS map so
+ * new games only need a new entry.
+ *
+ * Features:
+ * - Accessible disclosure pattern (aria-expanded / aria-controls / region)
+ * - Animated expand/collapse with reduced-motion support
+ * - Neubrutalism and Liquid theme styling
+ *
+ * @module components/games/GameInstructions
+ */
+
+import React, { useState } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { HelpCircle, ChevronDown } from 'lucide-react';
+import { useTheme } from '../shared/theme-context';
+import { GAME_INSTRUCTIONS } from './gameInstructionsData';
+
+/**
+ * Collapsible "How to Play" panel showing instructions for the active game.
+ *
+ * @component
+ * @param {object} props
+ * @param {string} props.gameId - Id of the currently selected game (key of GAME_INSTRUCTIONS).
+ * @returns {JSX.Element|null} The instructions disclosure, or null for unknown game ids.
+ */
+const GameInstructions = React.memo(({ gameId }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const shouldReduceMotion = useReducedMotion();
+  const { theme } = useTheme();
+  const isLiquid = theme === 'liquid';
+
+  const instructions = GAME_INSTRUCTIONS[gameId];
+  if (!instructions) return null;
+
+  const themeClass = (neubClass, liquidClass) => (isLiquid ? liquidClass : neubClass);
+  const panelId = `${gameId}-instructions`;
+
+  return (
+    <div className="w-full max-w-xl mx-auto mb-8">
+      <button
+        type="button"
+        onClick={() => setIsOpen(open => !open)}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        className={themeClass(
+          `w-full flex items-center justify-between gap-2 px-4 py-3 font-heading font-bold text-sm cursor-pointer
+            bg-secondary text-primary border-nb border-[color:var(--color-border)] rounded-nb
+            transition-transform motion-reduce:transform-none hover:-translate-x-0.5 hover:-translate-y-0.5`,
+          `w-full flex items-center justify-between gap-2 px-4 py-3 font-heading font-semibold text-sm cursor-pointer
+            lg-surface-2 text-[color:var(--text-primary)] rounded-full transition-all hover:brightness-110`
+        )}
+        style={isLiquid ? undefined : { boxShadow: '2px 2px 0 var(--color-border)' }}
+      >
+        <span className="flex items-center gap-2">
+          <HelpCircle size={18} aria-hidden="true" />
+          How to Play {instructions.title}
+        </span>
+        <motion.span
+          animate={{ rotate: isOpen ? 180 : 0 }}
+          transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.2 }}
+          className="flex"
+          aria-hidden="true"
+        >
+          <ChevronDown size={18} />
+        </motion.span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            key={gameId}
+            id={panelId}
+            role="region"
+            aria-label={`How to play ${instructions.title}`}
+            initial={shouldReduceMotion ? false : { height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={shouldReduceMotion ? undefined : { height: 0, opacity: 0 }}
+            transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div
+              className={themeClass(
+                'mt-3 px-5 py-4 bg-card border-nb border-[color:var(--color-border)] rounded-nb',
+                'mt-3 px-5 py-4 lg-surface-2 rounded-3xl'
+              )}
+              style={isLiquid ? undefined : { boxShadow: '2px 2px 0 var(--color-border)' }}
+            >
+              <p className="font-sans text-sm text-primary mb-3">
+                <span className="font-heading font-bold">Goal:</span> {instructions.goal}
+              </p>
+              <ol className="list-decimal list-inside space-y-2 font-sans text-sm text-secondary">
+                {instructions.steps.map(step => (
+                  <li key={step}>{step}</li>
+                ))}
+              </ol>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+});
+
+GameInstructions.displayName = 'GameInstructions';
+
+export default GameInstructions;

--- a/src/components/games/GameInstructions.test.jsx
+++ b/src/components/games/GameInstructions.test.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import GameInstructions from './GameInstructions';
+import { GAME_INSTRUCTIONS } from './gameInstructionsData';
+
+// Mock theme context
+vi.mock('../shared/theme-context', () => ({
+  useTheme: () => ({ theme: 'neubrutalism' }),
+}));
+
+// Mock framer-motion to bypass animations
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }) => {
+      const domProps = { ...props };
+      ['initial', 'animate', 'exit', 'transition', 'whileTap', 'whileHover', 'variants'].forEach(
+        k => delete domProps[k]
+      );
+      return <div {...domProps}>{children}</div>;
+    },
+    span: ({ children, ...props }) => {
+      const domProps = { ...props };
+      ['initial', 'animate', 'exit', 'transition', 'whileTap', 'whileHover', 'variants'].forEach(
+        k => delete domProps[k]
+      );
+      return <span {...domProps}>{children}</span>;
+    },
+  },
+  AnimatePresence: ({ children }) => <>{children}</>,
+  useReducedMotion: () => true,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('GameInstructions', () => {
+  it('renders a collapsed disclosure button for the given game', () => {
+    render(<GameInstructions gameId="snake" />);
+    const button = screen.getByRole('button', { name: /how to play snake/i });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('region')).not.toBeInTheDocument();
+  });
+
+  it('expands to show goal and steps when clicked', () => {
+    render(<GameInstructions gameId="snake" />);
+    const button = screen.getByRole('button', { name: /how to play snake/i });
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    const region = screen.getByRole('region', { name: /how to play snake/i });
+    expect(region).toBeInTheDocument();
+    expect(screen.getByText(/eat as much food as you can/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(GAME_INSTRUCTIONS.snake.steps.length);
+  });
+
+  it('collapses again when clicked twice', () => {
+    render(<GameInstructions gameId="tictactoe" />);
+    const button = screen.getByRole('button', { name: /how to play tic tac toe/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('region')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for an unknown game id', () => {
+    const { container } = render(<GameInstructions gameId="unknown-game" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('has instructions with a goal and steps for every game', () => {
+    const gameIds = [
+      'tictactoe',
+      'snake',
+      'memory',
+      'minesweeper',
+      'simon',
+      'whack',
+      'lightsout',
+      '2048',
+      'connectfour',
+    ];
+    gameIds.forEach(id => {
+      const entry = GAME_INSTRUCTIONS[id];
+      expect(entry, `missing instructions for ${id}`).toBeDefined();
+      expect(entry.title).toBeTruthy();
+      expect(entry.goal).toBeTruthy();
+      expect(entry.steps.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/components/games/gameInstructionsData.js
+++ b/src/components/games/gameInstructionsData.js
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview Instruction content for the Games page "How to Play" panels.
+ *
+ * Data-only module so new games just need a new entry here, keyed by the
+ * game id used on the Games page.
+ *
+ * @module components/games/gameInstructionsData
+ */
+
+/**
+ * Instruction content for every game on the Games page, keyed by game id.
+ *
+ * @type {Object<string, {title: string, goal: string, steps: string[]}>}
+ */
+export const GAME_INSTRUCTIONS = {
+  tictactoe: {
+    title: 'Tic Tac Toe',
+    goal: 'Get three X marks in a row — horizontally, vertically, or diagonally — before the AI does.',
+    steps: [
+      'Click any empty cell to place your X. The AI responds with an O.',
+      'Block the AI from completing three O in a row while building your own line.',
+      'Pick a difficulty: Easy plays randomly, Medium mixes it up, and Hard plays a perfect game.',
+      'When a round ends, press Play Again (or Escape) to start the next one. Scores carry over.',
+    ],
+  },
+  snake: {
+    title: 'Snake',
+    goal: 'Eat as much food as you can to grow the snake without crashing.',
+    steps: [
+      'Steer with the arrow keys, or swipe on touch screens.',
+      'Each piece of food grows the snake and adds to your score.',
+      'Avoid the walls and your own tail — hitting either ends the game.',
+      'Press Space or Escape to pause and resume.',
+    ],
+  },
+  memory: {
+    title: 'Memory Match',
+    goal: 'Find all 8 matching pairs of tech icons in as few moves as possible.',
+    steps: [
+      'Click a card to flip it over, then flip a second card to look for its match.',
+      'Matching pairs stay face up; mismatches flip back — remember where they were!',
+      'You can also navigate with the arrow keys and flip with Enter or Space.',
+      'Match every pair to win. Your best move count is saved.',
+    ],
+  },
+  minesweeper: {
+    title: 'Minesweeper',
+    goal: 'Reveal every safe cell without detonating a mine.',
+    steps: [
+      'Click a cell to reveal it. A number shows how many mines touch that cell.',
+      'Use the numbers to deduce where mines are hiding.',
+      'Right-click, long-press, or press F to flag a cell you suspect is a mine.',
+      'Reveal all safe cells to win — but one wrong click on a mine ends the game.',
+    ],
+  },
+  simon: {
+    title: 'Simon Says',
+    goal: 'Repeat an ever-growing sequence of colors for as long as you can.',
+    steps: [
+      'Watch the colored buttons flash in sequence.',
+      'Repeat the sequence by clicking the buttons in the same order.',
+      'Each round adds one more step to the sequence.',
+      'You can also use keys 1–4 for the buttons. One wrong press ends the run.',
+    ],
+  },
+  whack: {
+    title: 'Whack-a-Mole',
+    goal: 'Whack as many moles as you can before the 30-second timer runs out.',
+    steps: [
+      'Click a mole as soon as it pops out of its hole to score a point.',
+      'Moles pop up faster as the game goes on — stay sharp!',
+      'You can also use keys 1–9, which map to the 3×3 grid of holes.',
+      'Beat your high score before the clock hits zero.',
+    ],
+  },
+  lightsout: {
+    title: 'Lights Out',
+    goal: 'Turn off every light on the 5×5 grid in as few moves as possible.',
+    steps: [
+      'Click a light to toggle it along with its neighbors above, below, left, and right.',
+      'Plan ahead — every press flips up to five lights at once.',
+      'You can also move with the arrow keys and toggle with Enter or Space.',
+      'Every puzzle is solvable. Your fewest-moves record is saved.',
+    ],
+  },
+  2048: {
+    title: '2048',
+    goal: 'Merge matching tiles until you build the 2048 tile.',
+    steps: [
+      'Slide all tiles with the arrow keys (or WASD), or swipe on touch screens.',
+      'Tiles with the same number merge into one when they collide.',
+      'A new tile appears after every move, so keep the board tidy.',
+      'Reach 2048 to win — then keep playing for a higher score if you like.',
+    ],
+  },
+  connectfour: {
+    title: 'Connect Four',
+    goal: 'Connect four of your discs in a row — across, down, or diagonally — before the AI.',
+    steps: [
+      'Click a column to drop your disc; it falls to the lowest empty slot.',
+      'Alternate turns with the AI and block its lines while building your own.',
+      'You can also use the arrow keys plus Enter or Space, or press 1–7 to pick a column.',
+      'Choose a difficulty to change how far ahead the AI thinks.',
+    ],
+  },
+};

--- a/src/components/pages/Games.jsx
+++ b/src/components/pages/Games.jsx
@@ -25,6 +25,7 @@ import ThemedButton from '../shared/ThemedButton';
 import ThemedCard from '../shared/ThemedCard';
 import ThemedChip from '../shared/ThemedChip';
 import { useTheme } from '../shared/theme-context';
+import GameInstructions from '../games/GameInstructions';
 
 // Lazy load game components to reduce initial bundle size
 const TicTacToe = lazy(() => import('../games/TicTacToe'));
@@ -241,6 +242,15 @@ const Games = React.memo(() => {
               />
             ))}
           </div>
+        </motion.div>
+
+        {/* How to Play Instructions */}
+        <motion.div
+          initial={shouldReduceMotion ? false : { opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={shouldReduceMotion ? { duration: 0 } : { delay: 0.25 }}
+        >
+          <GameInstructions gameId={activeGame} />
         </motion.div>
 
         {/* Game Container */}


### PR DESCRIPTION
## Summary

Adds a collapsible **"How to Play"** panel to the Games page, showing the goal, step-by-step instructions, and keyboard controls for the currently selected game — covering all 9 games (Tic Tac Toe, Snake, Memory Match, Minesweeper, Simon Says, Whack-a-Mole, Lights Out, 2048, Connect Four).

## Changes

- **`src/components/games/gameInstructionsData.js`** (new): Data-only module with a `GAME_INSTRUCTIONS` map keyed by game id. Each entry has a title, goal, and steps written from each game's actual mechanics and controls (e.g. Minesweeper's F-key/long-press flagging, Simon's 1–4 keys, Connect Four's 1–7 column keys, Snake's Space/Escape pause). Adding a future game only requires a new entry.
- **`src/components/games/GameInstructions.jsx`** (new): Collapsible disclosure component that renders the instructions for the active game. Uses the accessible disclosure pattern (`aria-expanded`, `aria-controls`, labeled `region`), supports both Neubrutalism and Liquid themes via the existing `themeClass` convention, and respects `prefers-reduced-motion`.
- **`src/components/pages/Games.jsx`**: Renders the panel between the game selector tabs and the game container; it follows the active tab, and the open/collapsed state persists while switching games.
- **`src/components/games/GameInstructions.test.jsx`** (new): 5 tests covering collapsed default state, expand/collapse behavior, ARIA attributes, unknown game ids, and that every game id has complete instruction data.

## Testing

- `pnpm vitest run` — all 32 test files, 437 tests pass (including the 5 new ones)
- `eslint` clean with `--max-warnings 0` (instructions data extracted to its own module to satisfy `react-refresh/only-export-components`)
- `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh9tTRniSoWedammfMLBec

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh9tTRniSoWedammfMLBec)_